### PR TITLE
Install missing dependencies on OCP build

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,5 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
+RUN yum install -y gpgme-devel libassuan-devel
 COPY . .
 RUN make build --warn-undefined-variables
 


### PR DESCRIPTION
For some reason, `gpgme-devel` and `libassuan-devel` were not present during my attempt to build this image on brew, which made the build fail with the following error:

```
vendor/github.com/mtrmac/gpgme/data.go:4:20: fatal error: gpgme.h: No such file or directory
 // #include <gpgme.h>
                    ^
compilation terminated.
make: *** [build] Error 2
```

According to <https://github.com/openshift/openshift-controller-manager/blob/master/vendor/github.com/containers/image/README.md#building>, `libostree-devel` is also a requirement, but it built just fine on my tests without it.

I'm not sure if that is the best solution to the problem, was simply the minimum I needed to do in order to have a successful build; maybe we can have some input from @sosiouxme.