### PR TITLE
Bug 1730722: Add blocked registries to registries.conf

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1975,6 +1975,9 @@ func (bc *BuildController) createBuildRegistriesConfigData(config *configv1.Imag
 			Insecure: registryList{
 				Registries: registriesConfig.InsecureRegistries,
 			},
+			Block: registryList{
+				Registries: registriesConfig.BlockedRegistries,
+			},
 		},
 	}
 


### PR DESCRIPTION
When generating registries.conf, add the list of blocked registries from config.Spec.RegistrySources.BlockedRegistries to the list of registries in the [registries.block] section.