### PR TITLE
Set BUILD_REGISTRY_SOURCES to the cluster config

### DIFF
--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -643,7 +643,7 @@ func TestCreateBuildPodWithImageStreamUnresolved(t *testing.T) {
 
 type errorStrategy struct{}
 
-func (*errorStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*corev1.Pod, error) {
+func (*errorStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySources string) (*corev1.Pod, error) {
 	return nil, fmt.Errorf("error")
 }
 

--- a/pkg/build/controller/build/podcreationstrategy.go
+++ b/pkg/build/controller/build/podcreationstrategy.go
@@ -11,7 +11,7 @@ import (
 // buildPodCreationStrategy is used by the build controller to
 // create a build pod based on a build strategy
 type buildPodCreationStrategy interface {
-	CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*corev1.Pod, error)
+	CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySources string) (*corev1.Pod, error)
 }
 
 type typeBasedFactoryStrategy struct {
@@ -20,16 +20,16 @@ type typeBasedFactoryStrategy struct {
 	customBuildStrategy buildPodCreationStrategy
 }
 
-func (f *typeBasedFactoryStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*corev1.Pod, error) {
+func (f *typeBasedFactoryStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySources string) (*corev1.Pod, error) {
 	var pod *corev1.Pod
 	var err error
 	switch {
 	case build.Spec.Strategy.DockerStrategy != nil:
-		pod, err = f.dockerBuildStrategy.CreateBuildPod(build, additionalCAs, internalRegistryHost)
+		pod, err = f.dockerBuildStrategy.CreateBuildPod(build, additionalCAs, internalRegistryHost, registrySources)
 	case build.Spec.Strategy.SourceStrategy != nil:
-		pod, err = f.sourceBuildStrategy.CreateBuildPod(build, additionalCAs, internalRegistryHost)
+		pod, err = f.sourceBuildStrategy.CreateBuildPod(build, additionalCAs, internalRegistryHost, registrySources)
 	case build.Spec.Strategy.CustomStrategy != nil:
-		pod, err = f.customBuildStrategy.CreateBuildPod(build, additionalCAs, internalRegistryHost)
+		pod, err = f.customBuildStrategy.CreateBuildPod(build, additionalCAs, internalRegistryHost, registrySources)
 	case build.Spec.Strategy.JenkinsPipelineStrategy != nil:
 		return nil, fmt.Errorf("creating a build pod for Build %s/%s with the JenkinsPipeline strategy is not supported", build.Namespace, build.Name)
 	default:

--- a/pkg/build/controller/build/podcreationstrategy_test.go
+++ b/pkg/build/controller/build/podcreationstrategy_test.go
@@ -14,7 +14,7 @@ type testPodCreationStrategy struct {
 	err error
 }
 
-func (s *testPodCreationStrategy) CreateBuildPod(b *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*v1.Pod, error) {
+func (s *testPodCreationStrategy) CreateBuildPod(b *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySources string) (*v1.Pod, error) {
 	return s.pod, s.err
 }
 
@@ -48,6 +48,10 @@ func TestStrategyCreateBuildPod(t *testing.T) {
 	}
 
 	const internalRegistryHost = "registry.svc.localhost:5000"
+	const registrySources = `{
+		"InsecureRegistries": ["registry.svc.localhost:5000"],
+		"AllowedRegistries":  ["registry.svc.localhost:5000"]
+	}`
 
 	tests := []struct {
 		strategy    buildPodCreationStrategy
@@ -98,7 +102,7 @@ func TestStrategyCreateBuildPod(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		pod, err := test.strategy.CreateBuildPod(test.build, nil, internalRegistryHost)
+		pod, err := test.strategy.CreateBuildPod(test.build, nil, internalRegistryHost, registrySources)
 		if test.expectError {
 			if err == nil {
 				t.Errorf("Expected error but did not get one")

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -33,7 +33,7 @@ type CustomBuildStrategy struct {
 }
 
 // CreateBuildPod creates the pod to be used for the Custom build
-func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*corev1.Pod, error) {
+func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySourcesData string) (*corev1.Pod, error) {
 	strategy := build.Spec.Strategy.CustomStrategy
 	if strategy == nil {
 		return nil, errors.New("CustomBuildStrategy cannot be executed without CustomStrategy parameters")
@@ -136,7 +136,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	setupSourceSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.SourceSecret)
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
 	setupAdditionalSecrets(pod, &pod.Spec.Containers[0], build.Spec.Strategy.CustomStrategy.Secrets)
-	setupContainersConfigs(build, pod)
+	setupContainersConfigs(build, pod, registrySourcesData)
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	return pod, nil

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -26,12 +26,12 @@ func TestCustomCreateBuildPod(t *testing.T) {
 		Kind: "DockerImage",
 		Name: "",
 	}
-	if _, err := strategy.CreateBuildPod(expectedBad, nil, testInternalRegistryHost); err == nil {
+	if _, err := strategy.CreateBuildPod(expectedBad, nil, testInternalRegistryHost, testRegistrySources); err == nil {
 		t.Errorf("Expected error when Image is empty, got nothing")
 	}
 
 	build := mockCustomBuild(false, false)
-	actual, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+	actual, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestCustomCreateBuildPodExpectedForcePull(t *testing.T) {
 	strategy := CustomBuildStrategy{}
 
 	expected := mockCustomBuild(true, false)
-	actual, fperr := strategy.CreateBuildPod(expected, nil, testInternalRegistryHost)
+	actual, fperr := strategy.CreateBuildPod(expected, nil, testInternalRegistryHost, testRegistrySources)
 	if fperr != nil {
 		t.Fatalf("Unexpected error: %v", fperr)
 	}
@@ -139,7 +139,7 @@ func TestEmptySource(t *testing.T) {
 	strategy := CustomBuildStrategy{}
 
 	expected := mockCustomBuild(false, true)
-	_, fperr := strategy.CreateBuildPod(expected, nil, testInternalRegistryHost)
+	_, fperr := strategy.CreateBuildPod(expected, nil, testInternalRegistryHost, testRegistrySources)
 	if fperr != nil {
 		t.Fatalf("Unexpected error: %v", fperr)
 	}
@@ -153,7 +153,7 @@ func TestCustomCreateBuildPodWithCustomCodec(t *testing.T) {
 		build := mockCustomBuild(false, false)
 		build.Spec.Strategy.CustomStrategy.BuildAPIVersion = fmt.Sprintf("%s/%s", version.Group, version.Version)
 
-		pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+		pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -177,7 +177,7 @@ func TestCustomBuildLongName(t *testing.T) {
 	strategy := CustomBuildStrategy{}
 	build := mockCustomBuild(false, false)
 	build.Name = strings.Repeat("a", validation.DNS1123LabelMaxLength*2)
-	pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+	pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -31,7 +31,7 @@ type DockerBuildStrategy struct {
 
 // CreateBuildPod creates the pod to be used for the Docker build
 // TODO: Make the Pod definition configurable
-func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*v1.Pod, error) {
+func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySourcesData string) (*v1.Pod, error) {
 	data, err := runtime.Encode(buildJSONCodec, build)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode the build: %v", err)
@@ -192,7 +192,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	// TODO: consider moving this into the git-clone container and doing the secret copying there instead.
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
 	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
-	setupContainersConfigs(build, pod)
+	setupContainersConfigs(build, pod, registrySourcesData)
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -23,7 +23,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	}
 
 	build := mockDockerBuild()
-	actual, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+	actual, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -63,6 +63,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		"PULL_DOCKERCFG_PATH":         "",
 		"BUILD_REGISTRIES_CONF_PATH":  "",
 		"BUILD_REGISTRIES_DIR_PATH":   "",
+		"BUILD_REGISTRY_SOURCES":      "",
 		"BUILD_SIGNATURE_POLICY_PATH": "",
 		"BUILD_STORAGE_CONF_PATH":     "",
 		"BUILD_ISOLATION":             "",
@@ -154,7 +155,7 @@ func TestDockerBuildLongName(t *testing.T) {
 	}
 	build := mockDockerBuild()
 	build.Name = strings.Repeat("a", validation.DNS1123LabelMaxLength*2)
-	pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+	pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -31,7 +31,7 @@ var DefaultDropCaps = []string{
 
 // CreateBuildPod creates a pod that will execute the STI build
 // TODO: Make the Pod definition configurable
-func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost string) (*corev1.Pod, error) {
+func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCAs map[string]string, internalRegistryHost, registrySourcesData string) (*corev1.Pod, error) {
 	data, err := runtime.Encode(buildJSONCodec, build)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode the Build %s/%s: %v", build.Namespace, build.Name, err)
@@ -198,7 +198,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	// TODO: consider moving this into the git-clone container and doing the secret copying there instead.
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
 	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
-	setupContainersConfigs(build, pod)
+	setupContainersConfigs(build, pod, registrySourcesData)
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -56,7 +56,7 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	}
 
 	build := mockSTIBuild()
-	actual, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+	actual, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -99,6 +99,7 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 		"PULL_DOCKERCFG_PATH":         "",
 		"BUILD_REGISTRIES_CONF_PATH":  "",
 		"BUILD_REGISTRIES_DIR_PATH":   "",
+		"BUILD_REGISTRY_SOURCES":      "",
 		"BUILD_SIGNATURE_POLICY_PATH": "",
 		"BUILD_STORAGE_CONF_PATH":     "",
 		"BUILD_STORAGE_DRIVER":        "",
@@ -214,7 +215,7 @@ func TestS2IBuildLongName(t *testing.T) {
 	}
 	build := mockSTIBuild()
 	build.Name = strings.Repeat("a", validation.DNS1123LabelMaxLength*2)
-	pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost)
+	pod, err := strategy.CreateBuildPod(build, nil, testInternalRegistryHost, testRegistrySources)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}


### PR DESCRIPTION
Set $BUILD_REGISTRY_SOURCES in the build pod to a JSON-encoded copy of the cluster image config's Registry Sources structure, so that the builder can enforce blocked/allowed registry lists without getting tangled up in the existing use cases for `policy.json` and `registries.conf`.