### PR TITLE
Bug 1730722: Add blocked registries to registries.conf

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1961,8 +1961,8 @@ func (bc *BuildController) getAdditionalTrustedCAData(config *configv1.Image) (m
 
 func (bc *BuildController) createBuildRegistriesConfigData(config *configv1.Image) (string, error) {
 	registriesConfig := config.Spec.RegistrySources
-	if len(registriesConfig.InsecureRegistries) == 0 {
-		klog.V(4).Info("using default insecure registry settings for builds")
+	if len(registriesConfig.InsecureRegistries) == 0 && len(registriesConfig.BlockedRegistries) == 0 {
+		klog.V(4).Info("using default registry settings for builds")
 		return "", nil
 	}
 	configObj := tomlConfig{
@@ -1975,6 +1975,9 @@ func (bc *BuildController) createBuildRegistriesConfigData(config *configv1.Imag
 			Insecure: registryList{
 				Registries: registriesConfig.InsecureRegistries,
 			},
+			Block: registryList{
+				Registries: registriesConfig.BlockedRegistries,
+			},
 		},
 	}
 
@@ -1983,10 +1986,10 @@ func (bc *BuildController) createBuildRegistriesConfigData(config *configv1.Imag
 		return "", err
 	}
 	if len(configTOML) == 0 {
-		klog.V(4).Info("using default insecure registry settings for builds")
+		klog.V(4).Info("using default registry settings for builds")
 		return "", nil
 	}
-	klog.V(4).Info("overrode insecure registry settings for builds")
+	klog.V(4).Info("overrode registry settings for builds")
 	klog.V(5).Infof("generated registries.conf for build pods: \n%s", string(configTOML))
 	return string(configTOML), nil
 }

--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -1542,9 +1542,16 @@ func TestHandleControllerConfig(t *testing.T) {
 					registriesConfig.Registries.Insecure.Registries)
 			}
 
+			if !equality.Semantic.DeepEqual(registriesConfig.Registries.Block.Registries,
+				buildRegistriesConfig.BlockedRegistries) {
+				t.Errorf("expected blocked registries to equal %v, got %v",
+					buildRegistriesConfig.BlockedRegistries,
+					registriesConfig.Registries.Block.Registries)
+			}
+
 			expectedSearchRegistries := []string{}
 			// If only insecure registries are specified, default search should be docker.io
-			if len(buildRegistriesConfig.InsecureRegistries) > 0 {
+			if !isRegistryConfigEmpty(buildRegistriesConfig) {
 				expectedSearchRegistries = []string{"docker.io"}
 			}
 			if !equality.Semantic.DeepEqual(registriesConfig.Registries.Search.Registries,
@@ -1620,7 +1627,7 @@ func TestHandleControllerConfig(t *testing.T) {
 }
 
 func isRegistryConfigEmpty(config configv1.RegistrySources) bool {
-	return len(config.InsecureRegistries) == 0
+	return len(config.InsecureRegistries) == 0 && len(config.BlockedRegistries) == 0
 }
 
 func decodeRegistries(configTOML string) (*tomlConfig, error) {


### PR DESCRIPTION
When generating registries.conf, add the list of blocked registries from
config.Spec.RegistrySources.BlockedRegistries to the list of registries
in the [registries.block] section.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>, Adam Kaplan <adam.kaplan@redhat.com>