### PR TITLE
Bug 1748271: Copy global CA data to builds

### DIFF
--- a/pkg/build/buildutil/util.go
+++ b/pkg/build/buildutil/util.go
@@ -36,13 +36,12 @@ const (
 	BuildBlobsContentCache = "/var/cache/blobs"
 
 	// buildPodSuffix is the suffix used to append to a build pod name given a build name
-	buildPodSuffix          = "build"
-	caConfigMapSuffix       = "ca"
-	globalCAConfigMapSuffix = "global-ca"
-	// GlobalCAConfigMapLabel is the annotation key to set on a config map so that the platform's
-	// global CA support that will inject any required CA's needed for external communication.
-	GlobalCAConfigMapLabel   = "config.openshift.io/inject-trusted-cabundle"
+	buildPodSuffix           = "build"
+	caConfigMapSuffix        = "ca"
+	globalCAConfigMapSuffix  = "global-ca"
 	sysConfigConfigMapSuffix = "sys-config"
+	// GlobalCAConfigMapKey is the key into the config map data for the injected CA data
+	GlobalCAConfigMapKey = "ca-bundle.crt"
 )
 
 func HasTriggerType(triggerType buildv1.BuildTriggerType, bc *buildv1.BuildConfig) bool {

--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1820,9 +1820,30 @@ func (bc *BuildController) createBuildGlobalCAConfigMapSpec(build *buildv1.Build
 			OwnerReferences: []metav1.OwnerReference{
 				makeBuildPodOwnerRef(buildPod),
 			},
-			Labels: map[string]string{buildutil.GlobalCAConfigMapLabel: "true"},
 		},
+		Data: map[string]string{},
 	}
+
+	globalCAMap, err := bc.controllerManagerConfigMapStore.ConfigMaps("openshift-controller-manager").Get("openshift-global-ca")
+	if errors.IsNotFound(err) {
+		klog.V(2).Infof("WARNING - global certificate authority could not be found. If a proxy with a custom CA is being employed, build %s/%s will fail.", build.Namespace, build.Name)
+		return cm
+	}
+	if err != nil {
+		klog.V(1).Infof("ERROR - failed to read global certificate authority. If a proxy with a custom CA is being employed, build %s/%s will fail. Error: %v", build.Namespace, build.Name, err)
+		return cm
+	}
+	if globalCAMap == nil || len(globalCAMap.Data) == 0 {
+		klog.V(2).Infof("WARNING - global certificate authority data is not available. If a proxy with a custom CA is being employed, build %s/%s will fail.", build.Namespace, build.Name)
+		return cm
+
+	}
+	globalCAData, exists := globalCAMap.Data[buildutil.GlobalCAConfigMapKey]
+	if !exists {
+		klog.V(2).Infof("WARNING - global certificate authority data is missing. If a proxy with a custom CA is being employed, build %s/%s will fail.", build.Namespace, build.Name)
+		return cm
+	}
+	cm.Data[buildutil.GlobalCAConfigMapKey] = globalCAData
 	return cm
 }
 

--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -1261,12 +1261,6 @@ func TestCreateBuildProxyCAConfigMap(t *testing.T) {
 	if !hasBuildPodOwnerRef(pod, caMap) {
 		t.Error("build proxy CA configMap is missing owner ref to the build pod")
 	}
-	if caMap.Labels == nil || len(caMap.Labels) == 0 {
-		t.Errorf("build proxy CA config map has empty annotations")
-	}
-	if _, ok := caMap.Labels[buildutil.GlobalCAConfigMapLabel]; !ok {
-		t.Errorf("build proxy configMap is missing the proxy CA annotation")
-	}
 }
 
 func TestHandleControllerConfig(t *testing.T) {

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -550,7 +550,7 @@ func setupBuildCAs(build *buildv1.Build, pod *corev1.Pod, additionalCAs map[stri
 			//the TBD global CA injector will update the ConfigMapVolumeSource keyToPath items
 			Items: []corev1.KeyToPath{
 				{
-					Key:  "ca-bundle.crt",
+					Key:  buildutil.GlobalCAConfigMapKey,
 					Path: "tls-ca-bundle.pem",
 				},
 			},


### PR DESCRIPTION
…builds

/assign @bparees

@openshift/openshift-team-developer-experience FYI

per recent discussion on devex and warroom-proxy slack around https://bugzilla.redhat.com/show_bug.cgi?id=1748271

this consumes the config map created and labeled by ocm-o in PR https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/118, vs. creating/labeling a configmap for each build, to access the global CA data.

If we are happy with this new approach, I'll label this PR for the bugzilla 