### PR TITLE
Bug 1749557: new containers/image requires context with docker reference NewImageS…

### DIFF
--- a/pkg/image/controller/signature/container_image_downloader.go
+++ b/pkg/image/controller/signature/container_image_downloader.go
@@ -36,7 +36,11 @@ func (s *containerImageSignatureDownloader) DownloadImageSignatures(image *image
 	if err != nil {
 		return nil, err
 	}
-	source, err := reference.NewImageSource(nil, nil)
+
+	ctx, cancel := context.WithTimeout(s.ctx, s.timeout)
+	defer cancel()
+
+	source, err := reference.NewImageSource(ctx, nil)
 	if err != nil {
 		// In case we fail to talk to registry to get the image metadata (private
 		// registry, internal registry, etc...), do not fail with error to avoid
@@ -45,9 +49,6 @@ func (s *containerImageSignatureDownloader) DownloadImageSignatures(image *image
 		return []imagev1.ImageSignature{}, nil
 	}
 	defer source.Close()
-
-	ctx, cancel := context.WithTimeout(s.ctx, s.timeout)
-	defer cancel()
 
 	signatures, err := source.GetSignatures(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
…ource

more stringent context requirements (new remote calls added) for download image signatures with new containers/image from recent bump

/assign @bparees 
/assign @adambkaplan 
@openshift/openshift-team-developer-experience FYI / PTAL

