### PR TITLE
Use StatefulSets apps/v1 api, v1beta1 is going to be dropped

### DIFF
--- a/pkg/cmd/controller/image.go
+++ b/pkg/cmd/controller/image.go
@@ -74,8 +74,8 @@ func RunImageTriggerController(ctx *ControllerContext) (bool, error) {
 	})
 	sources = append(sources, imagetriggercontroller.TriggerSource{
 		Resource:  schema.GroupResource{Group: "apps", Resource: "statefulsets"},
-		Informer:  ctx.KubernetesInformers.Apps().V1beta1().StatefulSets().Informer(),
-		Store:     ctx.KubernetesInformers.Apps().V1beta1().StatefulSets().Informer().GetIndexer(),
+		Informer:  ctx.KubernetesInformers.Apps().V1().StatefulSets().Informer(),
+		Store:     ctx.KubernetesInformers.Apps().V1().StatefulSets().Informer().GetIndexer(),
 		TriggerFn: triggerannotations.NewAnnotationTriggerIndexer,
 		Reactor:   &triggerutil.AnnotationReactor{Updater: updater},
 	})


### PR DESCRIPTION
```
apiserver_request_count{client="openshift-controller-manager/v0.0.0 (linux/amd64) kubernetes/$Format",code="0",component="apiserver",contentType="application/vnd.kubernetes.protobuf;stream=watch",endpoint="https",group="apps",instance="10.0.160.62:6443",job="apiserver",namespace="default",resource="statefulsets",scope="cluster",service="kubernetes",verb="WATCH",version="v1beta1"}
```

/cc @soltysh @adambkaplan 