### PR TITLE
Bug 1774492: add push secret as pull secret with incremental builds

### DIFF
--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -192,6 +192,9 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 
 	setOwnerReference(pod, build)
 	setupDockerSecrets(pod, &pod.Spec.Containers[0], build.Spec.Output.PushSecret, strategy.PullSecret, build.Spec.Source.Images)
+	if strategy.Incremental != nil && *strategy.Incremental {
+		mountSecretVolume(pod, &pod.Spec.Containers[0], build.Spec.Output.PushSecret.Name, DockerPullSecretMountPath, "pull-incremental")
+	}
 	// For any secrets the user wants to reference from their Assemble script or Dockerfile, mount those
 	// secrets into the main container.  The main container includes logic to copy them from the mounted
 	// location into the working directory.


### PR DESCRIPTION
/assign @adambkaplan 

My analysis of the logs from this bug matched what you originally came up with @adambkaplan 

Here is my take on the raw fix

Took a quick scan at the unit tests and there isn't a starting point to easily add one for this

Most likely we would want to create an extended test equivalent of the reproducer in the bug for verification