### PR TITLE
Bug 1765294: Re-list pull secret controllers

### DIFF
--- a/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
+++ b/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
@@ -74,7 +74,7 @@ func NewDockercfgController(serviceAccounts informers.ServiceAccountInformer, se
 
 	serviceAccountCache := serviceAccounts.Informer().GetStore()
 	e.serviceAccountController = serviceAccounts.Informer().GetController()
-	serviceAccounts.Informer().AddEventHandlerWithResyncPeriod(
+	serviceAccounts.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				serviceAccount := obj.(*v1.ServiceAccount)
@@ -88,13 +88,12 @@ func NewDockercfgController(serviceAccounts informers.ServiceAccountInformer, se
 				e.enqueueServiceAccount(serviceAccount)
 			},
 		},
-		options.Resync,
 	)
 	e.serviceAccountCache = NewEtcdMutationCache(serviceAccountCache)
 
 	e.secretCache = secrets.Informer().GetIndexer()
 	e.secretController = secrets.Informer().GetController()
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	secrets.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -111,7 +110,6 @@ func NewDockercfgController(serviceAccounts informers.ServiceAccountInformer, se
 				DeleteFunc: e.handleTokenSecretDelete,
 			},
 		},
-		options.Resync,
 	)
 	e.syncHandler = e.syncServiceAccount
 

--- a/pkg/serviceaccounts/controllers/deleted_dockercfg_secrets.go
+++ b/pkg/serviceaccounts/controllers/deleted_dockercfg_secrets.go
@@ -34,7 +34,7 @@ func NewDockercfgDeletedController(secrets informers.SecretInformer, cl kclients
 	}
 
 	e.secretController = secrets.Informer().GetController()
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	secrets.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -49,7 +49,6 @@ func NewDockercfgDeletedController(secrets informers.SecretInformer, cl kclients
 				DeleteFunc: e.secretDeleted,
 			},
 		},
-		options.Resync,
 	)
 
 	return e

--- a/pkg/serviceaccounts/controllers/deleted_token_secrets.go
+++ b/pkg/serviceaccounts/controllers/deleted_token_secrets.go
@@ -31,7 +31,7 @@ func NewDockercfgTokenDeletedController(secrets informers.SecretInformer, cl kcl
 	}
 
 	e.secretController = secrets.Informer().GetController()
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	secrets.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -46,7 +46,6 @@ func NewDockercfgTokenDeletedController(secrets informers.SecretInformer, cl kcl
 				DeleteFunc: e.secretDeleted,
 			},
 		},
-		options.Resync,
 	)
 
 	return e


### PR DESCRIPTION
Use default relist intervals when managing the service account pull secrets.
Current controllers never relist, potentially missing delete events.