### PR TITLE
Remove ServiceNetworkCIDR Config

### DIFF
--- a/pkg/cmd/openshift-controller-manager/openshiftcontrolplane_default.go
+++ b/pkg/cmd/openshift-controller-manager/openshiftcontrolplane_default.go
@@ -16,8 +16,6 @@ func setRecommendedOpenShiftControllerConfigDefaults(config *openshiftcontrolpla
 
 	configdefaults.DefaultStringSlice(&config.Controllers, []string{"*"})
 
-	configdefaults.DefaultString(&config.Network.ServiceNetworkCIDR, "10.0.0.0/24")
-
 	if config.ImageImport.MaxScheduledImageImportsPerMinute == 0 {
 		config.ImageImport.MaxScheduledImageImportsPerMinute = 60
 	}


### PR DESCRIPTION
Remove defaulting of the ServiceNetworkCIDR configuration.
This has been replaced by the cluster ingress configurations.