### PR TITLE
Use Named Queues for Service Account Controller

### DIFF
--- a/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
+++ b/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
@@ -68,7 +68,7 @@ type DockercfgControllerOptions struct {
 func NewDockercfgController(serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer, cl kclientset.Interface, options DockercfgControllerOptions) *DockercfgController {
 	e := &DockercfgController{
 		client:                cl,
-		queue:                 workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "serviceaccount-create-dockercfg"),
 		dockerURLsInitialized: options.DockerURLsInitialized,
 	}
 

--- a/pkg/serviceaccounts/controllers/docker_registry_service.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service.go
@@ -58,8 +58,8 @@ func NewDockerRegistryServiceController(secrets informers.SecretInformer, servic
 		additionalRegistryURLs: options.AdditionalRegistryURLs,
 		clusterDNSSuffix:       options.ClusterDNSSuffix,
 		dockercfgController:    options.DockercfgController,
-		registryLocationQueue:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		secretsToUpdate:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		registryLocationQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "serviceaccount-registry-location"),
+		secretsToUpdate:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "serviceaccount-registry-location-reactions"),
 		dockerURLsInitialized:  options.DockerURLsInitialized,
 	}
 


### PR DESCRIPTION
Named queues will expose workload metrics to Prometheus.