### PR TITLE
Bug 1785023: Increase pull secrets controller QPS to 100

### DIFF
--- a/pkg/cmd/controller/serviceaccount.go
+++ b/pkg/cmd/controller/serviceaccount.go
@@ -43,7 +43,10 @@ func RunServiceAccountController(ctx *ControllerContext) (bool, error) {
 }
 
 func RunServiceAccountPullSecretsController(ctx *ControllerContext) (bool, error) {
-	kc := ctx.ClientBuilder.ClientOrDie(iInfraServiceAccountPullSecretsControllerServiceAccountName)
+	// Bug 1785023: Increase the rate limit for the SA Pull Secrets controller.
+	// The pull secrets controller needs to create new dockercfg secrets at the same rate as the
+	// upstream token secret controller.
+	kc := ctx.HighRateLimitClientBuilder.ClientOrDie(iInfraServiceAccountPullSecretsControllerServiceAccountName)
 
 	go serviceaccountcontrollers.NewDockercfgDeletedController(
 		ctx.KubernetesInformers.Core().V1().Secrets(),


### PR DESCRIPTION
Increase the k8s client QPS limit to 100, 200 burst for the service account pull secrets controller. This ensures that pull secrets for the registry are created as quickly as the tokens are generated.