### PR TITLE
Add component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,3 +11,4 @@ approvers:
   - mfojtik
   - soltysh
   - adambkaplan
+component: openshift-controller-manager


### PR DESCRIPTION
OCM links to the "openshift-controller-manager" component in bugzilla.