### PR TITLE
Bug 1825324: Use named queues for all controllers

### DIFF
--- a/pkg/apps/deployer/factory.go
+++ b/pkg/apps/deployer/factory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -39,7 +39,7 @@ func NewDeployerController(
 		rn: kubeClientset.CoreV1(),
 		pn: kubeClientset.CoreV1(),
 
-		queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "deployer"),
 
 		rcLister:        rcInformer.Lister(),
 		rcListerSynced:  rcInformer.Informer().HasSynced,

--- a/pkg/apps/deploymentconfig/factory.go
+++ b/pkg/apps/deploymentconfig/factory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -41,7 +41,7 @@ func NewDeploymentConfigController(
 		appsClient: appsClientset.AppsV1(),
 		kubeClient: kubeClientset.CoreV1(),
 
-		queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "deploymentconfig"),
 
 		rcLister:       rcInformer.Lister(),
 		rcListerSynced: rcInformer.Informer().HasSynced,

--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -261,10 +261,10 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 		buildOverrides:           params.BuildOverrides,
 		internalRegistryHostname: params.InternalRegistryHostname,
 
-		buildQueue:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		buildQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "build"),
 		imageStreamQueue:      newResourceTriggerQueue(),
-		buildConfigQueue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		controllerConfigQueue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		buildConfigQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "build-completed"),
+		controllerConfigQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "build-controller-config"),
 
 		recorder:    eventBroadcaster.NewRecorder(buildscheme.EncoderScheme, corev1.EventSource{Component: "build-controller"}),
 		runPolicies: policy.GetAllRunPolicies(buildLister, params.BuildClient.BuildV1()),

--- a/pkg/build/controller/buildconfig/buildconfig_controller.go
+++ b/pkg/build/controller/buildconfig/buildconfig_controller.go
@@ -82,7 +82,7 @@ func NewBuildConfigController(buildClient buildclient.Interface, kubeExternalCli
 
 		buildConfigInformer: buildConfigInformer.Informer(),
 
-		queue:    workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "buildconfig"),
 		recorder: eventBroadcaster.NewRecorder(buildscheme.EncoderScheme, corev1.EventSource{Component: "buildconfig-controller"}),
 	}
 

--- a/pkg/image/controller/signature/signature_import_controller.go
+++ b/pkg/image/controller/signature/signature_import_controller.go
@@ -41,7 +41,7 @@ type SignatureImportController struct {
 
 func NewSignatureImportController(ctx context.Context, imageClient imagev1client.Interface, imageInformer imagev1informer.ImageInformer, resyncInterval, fetchTimeout time.Duration, limit int) *SignatureImportController {
 	controller := &SignatureImportController{
-		queue:                workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "image-signature-import"),
 		imageClient:          imageClient,
 		imageLister:          imageInformer.Lister(),
 		imageHasSynced:       imageInformer.Informer().HasSynced,

--- a/pkg/project/controller/project_finalizer_controller.go
+++ b/pkg/project/controller/project_finalizer_controller.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -38,7 +38,7 @@ func NewProjectFinalizerController(namespaces corev1informers.NamespaceInformer,
 	c := &ProjectFinalizerController{
 		client:      client,
 		cacheSynced: namespaces.Informer().HasSynced,
-		queue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "project-finalizer"),
 		nsLister:    namespaces.Lister(),
 	}
 	namespaces.Informer().AddEventHandler(

--- a/pkg/route/ingressip/service_ingressip_controller.go
+++ b/pkg/route/ingressip/service_ingressip_controller.go
@@ -88,7 +88,7 @@ func NewIngressIPController(services cache.SharedIndexInformer, kc kclientset.In
 
 	ic := &IngressIPController{
 		client:     kc.CoreV1(),
-		queue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ingressip"),
 		maxRetries: 10,
 		recorder:   recorder,
 	}

--- a/pkg/unidling/controller/unidling_controller.go
+++ b/pkg/unidling/controller/unidling_controller.go
@@ -88,7 +88,7 @@ func NewUnidlingController(scaleNS scale.ScalesGetter, mapper meta.RESTMapper, e
 		scaleNamespacer:     scaleNS,
 		mapper:              mapper,
 		endpointsNamespacer: endptsNS,
-		queue:               workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "unidling"),
 		lastFiredCache: &lastFiredCache{
 			items: make(map[types.NamespacedName]time.Time),
 		},


### PR DESCRIPTION
* Add named queues for all ocm controllers
* This exposes the workqueue_* metrics to kube-state-metrics