### PR TITLE
test compile PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 ##### openshift-controller-manager
 
 TODO: Add content
+
+test PR to compare origin and ose build for the gpgme compile failure


### PR DESCRIPTION
@adambkaplan @joepvd @sosiouxme FYI ... let's see how this compare to the OSE failure

as @sosiouxme noted in https://coreos.slack.com/archives/CB95J6R4N/p1588170349277200 the OCP builder is suppose to be pushed to registry.ci for cross verification / validation reasons