### PR TITLE
Bug 1829863: update Dockerfile.rhel builder image to line up with art/brew/osbs

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables


### PR DESCRIPTION
Outcome of working session at https://coreos.slack.com/archives/CB95J6R4N/p1588170349277200 being able to use the golang 1.3 builder image used by brew/osbs 

Worked with @jupierce and @sosiouxme to line it up to install `gpgme-devel libassuan-devel` in that image

/hold

@adambkaplan @bparees FYI