### PR TITLE
Bug 1829447: ensure build pod activeDeadlineSeconds always set

### DIFF
--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -112,9 +112,8 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 			NodeSelector:  build.Spec.NodeSelector,
 		},
 	}
-	if build.Spec.CompletionDeadlineSeconds != nil {
-		pod.Spec.ActiveDeadlineSeconds = build.Spec.CompletionDeadlineSeconds
-	}
+
+	pod = setupActiveDeadline(pod, build)
 
 	if !strategy.ForcePull {
 		pod.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -198,9 +198,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		},
 	)
 
-	if build.Spec.CompletionDeadlineSeconds != nil {
-		pod.Spec.ActiveDeadlineSeconds = build.Spec.CompletionDeadlineSeconds
-	}
+	pod = setupActiveDeadline(pod, build)
 
 	setOwnerReference(pod, build)
 	setupDockerSecrets(pod, &pod.Spec.Containers[0], build.Spec.Output.PushSecret, strategy.PullSecret, build.Spec.Source.Images)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -205,9 +205,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		},
 	)
 
-	if build.Spec.CompletionDeadlineSeconds != nil {
-		pod.Spec.ActiveDeadlineSeconds = build.Spec.CompletionDeadlineSeconds
-	}
+	pod = setupActiveDeadline(pod, build)
 
 	setOwnerReference(pod, build)
 	setupDockerSecrets(pod, &pod.Spec.Containers[0], build.Spec.Output.PushSecret, strategy.PullSecret, build.Spec.Source.Images)


### PR DESCRIPTION
RunOnceDuration admission plugin no longer present in 4.x

/assign @adambkaplan 