### PR TITLE
Bug 1819770: Removing yum commands from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
-RUN yum install -y gpgme-devel libassuan-devel
 COPY . .
 RUN make build --warn-undefined-variables
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
-RUN yum install -y gpgme-devel libassuan-devel
 COPY . .
 RUN make build --warn-undefined-variables
 


### PR DESCRIPTION
These packages are already present on the base image, no need to install
them during the image build.

This PR has been created so we can once again build release 4.4 after
changes on https://github.com/openshift/release/pull/9029