### PR TITLE
Bug 1832294: Add strategy metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,15 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/images.mk \
 )
 
+IMAGE_REGISTRY :=registry.svc.ci.openshift.org
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name
-# $1 - target suffix
-# $2 - Dockerfile path
-# $3 - context directory for image build
-# It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-$(GO_PACKAGE),./Dockerfile,.)
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context directory for image build# It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
+$(call build-image,ocp-openshift-controller-manager,$(IMAGE_REGISTRY)/ocp/4.5:openshift-controller-manager, ./Dockerfile,.)
 
 clean:
 	$(RM) ./openshift-controller-manager

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: build
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
 	targets/openshift/images.mk \
+	targets/openshift/deps.mk \
 )
 
 IMAGE_REGISTRY :=registry.svc.ci.openshift.org

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/docker-credential-helpers v0.0.0-20190720063934-f78081d1f7fe // indirect
+	github.com/google/go-cmp v0.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,6 @@ github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/library-go v0.0.0-20200327125526-163b2f0d6264 h1:VcZjTupwjxB9ANlKxerMNdfjqlTBWrVxgrjKi7VBwOY=
 github.com/openshift/library-go v0.0.0-20200327125526-163b2f0d6264/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
-github.com/openshift/runtime-utils v0.0.0-20191011150825-9169de69ebf6 h1:JieAjgiriu9Z6TO2asY9giKpfTp+Dqyu0RWX21avjpQ=
-github.com/openshift/runtime-utils v0.0.0-20191011150825-9169de69ebf6/go.mod h1:5gDRVvQwesU7cfwlpuMivdv3Dz/oslvv2qTBHCy4wqQ=
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912 h1:zPJYcr+2g68K+pEqw7crr0vLSVsYb3B82LS3y7/kxpc=
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/apps/deploymentconfig/factory.go
+++ b/pkg/apps/deploymentconfig/factory.go
@@ -88,7 +88,7 @@ func (c *DeploymentConfigController) Run(workers int, stopCh <-chan struct{}) {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
 
-	metrics.InitializeMetricsCollector(c.rcLister)
+	metrics.InitializeMetricsCollector(c.dcLister, c.rcLister)
 
 	<-stopCh
 

--- a/pkg/apps/metrics/prometheus/metrics_test.go
+++ b/pkg/apps/metrics/prometheus/metrics_test.go
@@ -1,28 +1,31 @@
 package prometheus
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	appsv1 "github.com/openshift/api/apps/v1"
+	appslisters "github.com/openshift/client-go/apps/listers/apps/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
-
-	appsv1 "github.com/openshift/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/rand"
 	kcorelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics"
 )
 
 var (
-	timeNow          = metav1.Now()
+	timeNow          = metav1.NewTime(time.Unix(42, 42))
 	defaultTimeNowFn = func() time.Time { return timeNow.Time }
 )
 
@@ -36,18 +39,19 @@ func mockRC(name string, version int, annotations map[string]string, generation 
 	return r
 }
 
-type fakeLister []*corev1.ReplicationController
-
-func (f fakeLister) List(labels.Selector) ([]*corev1.ReplicationController, error) {
-	return f, nil
-}
-
-func (fakeLister) ReplicationControllers(string) kcorelisters.ReplicationControllerNamespaceLister {
-	return nil
-}
-
-func (fakeLister) GetPodControllers(*corev1.Pod) ([]*corev1.ReplicationController, error) {
-	return nil, nil
+func mockDCWithStrategy(t appsv1.DeploymentStrategyType) *appsv1.DeploymentConfig {
+	return &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			// we need unique keys for the indexer
+			Namespace: rand.SafeEncodeString(rand.String(10)),
+			Name:      rand.SafeEncodeString(rand.String(10)),
+		},
+		Spec: appsv1.DeploymentConfigSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: t,
+			},
+		},
+	}
 }
 
 type fakeResponseWriter struct {
@@ -64,46 +68,114 @@ func (f *fakeResponseWriter) WriteHeader(statusCode int) {
 	f.statusCode = statusCode
 }
 
+func completedAvailableMetric(v float64) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		completeRolloutCountDesc,
+		prometheus.GaugeValue,
+		v,
+		[]string{
+			"available",
+		}...,
+	)
+}
+
+func completedFailedMetric(v float64) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		completeRolloutCountDesc,
+		prometheus.GaugeValue,
+		v,
+		[]string{
+			"failed",
+		}...,
+	)
+}
+
+func completedCancelledMetric(v float64) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		completeRolloutCountDesc,
+		prometheus.GaugeValue,
+		v,
+		[]string{
+			"cancelled",
+		}...,
+	)
+}
+
+func lastFailedMetric(timestamp float64, namespace, name, latestVersion string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		lastFailedRolloutTimeDesc,
+		prometheus.GaugeValue,
+		timestamp,
+		[]string{
+			namespace,
+			name,
+			latestVersion,
+		}...,
+	)
+}
+
+func activeRolloutsDurationMetric(durationSec float64, namespace, name, phase, latestVersion string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		activeRolloutDurationSecondsDesc,
+		prometheus.CounterValue,
+		durationSec,
+		[]string{
+			namespace,
+			name,
+			phase,
+			latestVersion,
+		}...,
+	)
+}
+
+func strategyMetric(count float64, t string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		strategyCountDesc,
+		prometheus.GaugeValue,
+		count,
+		[]string{
+			t,
+		}...,
+	)
+}
+
 func TestCollect(t *testing.T) {
-	tests := []struct {
-		name  string
-		count int
-		rcs   []*corev1.ReplicationController
-		// expected values
-		available     float64
-		failed        float64
-		cancelled     float64
-		timestamp     float64
-		latestVersion string
+	tt := []struct {
+		name            string
+		rcs             []*corev1.ReplicationController
+		dcs             []*appsv1.DeploymentConfig
+		expectedMetrics []prometheus.Metric
 	}{
 		{
-			name:      "no deployments",
-			count:     3,
-			available: 0,
-			failed:    0,
-			cancelled: 0,
-			rcs:       []*corev1.ReplicationController{},
+			name: "no deployments",
+			rcs:  []*corev1.ReplicationController{},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				completedAvailableMetric(0),
+				completedFailedMetric(0),
+				completedCancelledMetric(0),
+			},
 		},
 		{
-			name:      "single successful deployment",
-			count:     3,
-			available: 1,
-			failed:    0,
-			cancelled: 0,
+			name: "single successful deployment",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentStatusAnnotation: string(appsv1.DeploymentStatusComplete),
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				completedAvailableMetric(1),
+				completedFailedMetric(0),
+				completedCancelledMetric(0),
+			},
 		},
 		{
-			name:          "single cancelled deployment",
-			count:         3,
-			available:     0,
-			failed:        0,
-			cancelled:     1,
-			latestVersion: "1",
-			timestamp:     float64(timeNow.Unix()),
+			name: "single cancelled deployment",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentCancelledAnnotation: "true",
@@ -111,30 +183,35 @@ func TestCollect(t *testing.T) {
 					appsv1.DeploymentVersionAnnotation:   "1",
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				completedAvailableMetric(0),
+				completedFailedMetric(0),
+				completedCancelledMetric(1),
+			},
 		},
 		{
-			name:          "single failed deployment",
-			count:         4,
-			available:     0,
-			failed:        1,
-			cancelled:     0,
-			latestVersion: "1",
-			timestamp:     float64(timeNow.Unix()),
+			name: "single failed deployment",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentStatusAnnotation:  string(appsv1.DeploymentStatusFailed),
 					appsv1.DeploymentVersionAnnotation: "1",
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				lastFailedMetric(float64(timeNow.Unix()), "test", "foo", "1"),
+				completedAvailableMetric(0),
+				completedFailedMetric(1),
+				completedCancelledMetric(0),
+			},
 		},
 		{
-			name:          "multiple failed deployment",
-			count:         4,
-			available:     0,
-			failed:        4,
-			cancelled:     0,
-			latestVersion: "4",
-			timestamp:     float64(timeNow.Unix()),
+			name: "multiple failed deployment",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentStatusAnnotation:  string(appsv1.DeploymentStatusFailed),
@@ -153,15 +230,18 @@ func TestCollect(t *testing.T) {
 					appsv1.DeploymentVersionAnnotation: "4",
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				lastFailedMetric(float64(timeNow.Unix()), "test", "foo", "4"),
+				completedAvailableMetric(0),
+				completedFailedMetric(4),
+				completedCancelledMetric(0),
+			},
 		},
 		{
-			name:          "single failed deployment within successful deployments",
-			count:         3,
-			available:     2,
-			failed:        1,
-			cancelled:     0,
-			latestVersion: "2",
-			timestamp:     float64(timeNow.Unix()),
+			name: "single failed deployment within successful deployments",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentStatusAnnotation:  string(appsv1.DeploymentStatusComplete),
@@ -176,34 +256,35 @@ func TestCollect(t *testing.T) {
 					appsv1.DeploymentVersionAnnotation: "3",
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				completedAvailableMetric(2),
+				completedFailedMetric(1),
+				completedCancelledMetric(0),
+			},
 		},
 		{
-			name:          "single active deployment",
-			count:         4,
-			available:     0,
-			failed:        0,
-			cancelled:     0,
-			latestVersion: "1",
-			// the timestamp is duration in this case, which is 0 as the creation time
-			// and current time are the same.
-			timestamp: 0,
+			name: "single active deployment",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentStatusAnnotation:  string(appsv1.DeploymentStatusRunning),
 					appsv1.DeploymentVersionAnnotation: "1",
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				activeRolloutsDurationMetric(0, "test", "foo", "running", "1"),
+				completedAvailableMetric(0),
+				completedFailedMetric(0),
+				completedCancelledMetric(0),
+			},
 		},
 		{
-			name:          "single active deployment with history",
-			count:         4,
-			available:     2,
-			failed:        0,
-			cancelled:     0,
-			latestVersion: "3",
-			// the timestamp is duration in this case, which is 0 as the creation time
-			// and current time are the same.
-			timestamp: 0,
+			name: "single active deployment with history",
 			rcs: []*corev1.ReplicationController{
 				mockRC("foo", 1, map[string]string{
 					appsv1.DeploymentStatusAnnotation:  string(appsv1.DeploymentStatusComplete),
@@ -218,122 +299,125 @@ func TestCollect(t *testing.T) {
 					appsv1.DeploymentVersionAnnotation: "3",
 				}, 0, timeNow),
 			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(0, "custom"),
+				strategyMetric(0, "recreate"),
+				strategyMetric(0, "rolling"),
+				activeRolloutsDurationMetric(0, "test", "foo", "running", "3"),
+				completedAvailableMetric(2),
+				completedFailedMetric(0),
+				completedCancelledMetric(0),
+			},
+		},
+		{
+			name: "dc strategy count",
+			dcs: []*appsv1.DeploymentConfig{
+				mockDCWithStrategy(appsv1.DeploymentStrategyTypeCustom),
+				mockDCWithStrategy(appsv1.DeploymentStrategyTypeRecreate),
+				mockDCWithStrategy(appsv1.DeploymentStrategyTypeRecreate),
+				mockDCWithStrategy(appsv1.DeploymentStrategyTypeRolling),
+				mockDCWithStrategy(appsv1.DeploymentStrategyTypeRolling),
+				mockDCWithStrategy(appsv1.DeploymentStrategyTypeRolling),
+			},
+			expectedMetrics: []prometheus.Metric{
+				strategyMetric(1, "custom"),
+				strategyMetric(2, "recreate"),
+				strategyMetric(3, "rolling"),
+				completedAvailableMetric(0),
+				completedFailedMetric(0),
+				completedCancelledMetric(0),
+			},
 		},
 	}
 
-	for _, c := range tests {
-		rcCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		fakeCollector := appsCollector{
-			lister: kcorelisters.NewReplicationControllerLister(rcCache),
-			nowFn:  defaultTimeNowFn,
-		}
-
-		for _, rc := range c.rcs {
-			if err := rcCache.Add(rc); err != nil {
-				t.Fatalf("unable to add rc %s: %v", rc.Name, err)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			dcCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			rcCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			collector := appsCollector{
+				dcLister: appslisters.NewDeploymentConfigLister(dcCache),
+				rcLister: kcorelisters.NewReplicationControllerLister(rcCache),
+				nowFn:    defaultTimeNowFn,
 			}
-		}
 
-		collectedMetrics := []prometheus.Metric{}
-		collectionChan := make(chan prometheus.Metric)
-		stopChan := make(chan struct{})
-		go func() {
-			defer close(collectionChan)
-			fakeCollector.Collect(collectionChan)
-			<-stopChan
-		}()
+			for _, dc := range tc.dcs {
+				err := dcCache.Add(dc)
+				if err != nil {
+					t.Fatalf("unable to add dc %s: %v", dc.Name, err)
+				}
+			}
 
-		for {
-			select {
-			case m := <-collectionChan:
+			for _, rc := range tc.rcs {
+				err := rcCache.Add(rc)
+				if err != nil {
+					t.Fatalf("unable to add rc %s: %v", rc.Name, err)
+				}
+			}
+
+			var collectedMetrics []prometheus.Metric
+			collectionChan := make(chan prometheus.Metric, 1000) // big enough buffer to contain all created metrics
+			collector.Collect(collectionChan)
+			close(collectionChan)
+			for m := range collectionChan {
 				collectedMetrics = append(collectedMetrics, m)
-			case <-time.After(time.Second * 5):
-				t.Fatalf("[%s] timeout receiving expected results (got %d, want %d)", c.name, len(collectedMetrics), c.count)
-			}
-			if len(collectedMetrics) == c.count {
-				close(stopChan)
-				break
-			}
-		}
-
-		if len(collectedMetrics) == 0 {
-			continue
-		}
-
-		for _, m := range collectedMetrics {
-			var out dto.Metric
-			m.Write(&out)
-
-			// last_failed_rollout_time
-			if strings.Contains(m.Desc().String(), nameToQuery(lastFailedRolloutTime)) {
-				gaugeValue := out.GetGauge().GetValue()
-				labels := out.GetLabel()
-				if gaugeValue != c.timestamp {
-					t.Errorf("[%s][last_failed_rollout_time] creation timestamp %f does not match expected timestamp: %f", c.name, gaugeValue, c.timestamp)
-				}
-				for _, l := range labels {
-					if l.GetName() == "latest_version" && l.GetValue() != c.latestVersion {
-						t.Errorf("[%s][last_failed_rollout_time] latest_version %q does not match expected version %q", c.name, l.GetValue(), c.latestVersion)
-					}
-				}
-				continue
 			}
 
-			// active_rollouts_duration_seconds
-			if strings.Contains(m.Desc().String(), nameToQuery(activeRolloutDurationSeconds)) {
-				gaugeValue := out.GetGauge().GetValue()
-				labels := out.GetLabel()
-				if gaugeValue != c.timestamp {
-					t.Errorf("[%s][active_rollouts_duration_seconds] creation timestamp %f does not match expected timestamp: %f", c.name, gaugeValue, c.timestamp)
+			d := cmp.Diff(tc.expectedMetrics, collectedMetrics, cmp.Comparer(func(lhs prometheus.Metric, rhs prometheus.Metric) bool {
+				var lhsOut dto.Metric
+				err := lhs.Write(&lhsOut)
+				if err != nil {
+					t.Fatal(nil)
 				}
-				for _, l := range labels {
-					if l.GetName() == "latest_version" && l.GetValue() != c.latestVersion {
-						t.Errorf("[%s][active_rollouts_duration_seconds] latest_version %q does not match expected version %q", c.name, l.GetValue(), c.latestVersion)
-					}
+				var rhsOut dto.Metric
+				err = rhs.Write(&rhsOut)
+				if err != nil {
+					t.Fatal(nil)
 				}
-				continue
-			}
 
-			// complete_rollouts_total
-			if strings.Contains(m.Desc().String(), nameToQuery(completeRolloutCount)) {
-				gaugeValue := out.GetGauge().GetValue()
-				switch out.GetLabel()[0].GetValue() {
-				case availablePhase:
-					if c.available != gaugeValue {
-						t.Errorf("[%s][complete_rollouts_total] expected available %f, got %f", c.name, c.available, gaugeValue)
-					}
-				case failedPhase:
-					if c.failed != gaugeValue {
-						t.Errorf("[%s][complete_rollouts_total] expected failed %f, got %f", c.name, c.failed, gaugeValue)
-					}
-				case cancelledPhase:
-					if c.cancelled != gaugeValue {
-						t.Errorf("[%s][]complete_rollouts_total expected cancelled %f, got %f", c.name, c.cancelled, gaugeValue)
-					}
-				}
-				continue
+				return reflect.DeepEqual(lhs.Desc(), rhs.Desc()) && reflect.DeepEqual(lhsOut, rhsOut)
+			}))
+			if len(d) > 0 {
+				t.Errorf("expected and collected metrics differ: %s", d)
 			}
-
-			t.Errorf("[%s] unexpected metric recorded: %s", c.name, m.Desc().String())
-		}
+		})
 	}
 }
 
-func TestLegacyRegistry(t *testing.T) {
-	expectedResponse := []string{
-		"# HELP openshift_apps_deploymentconfigs_active_rollouts_duration_seconds Tracks the active rollout duration in seconds",
-		"# TYPE openshift_apps_deploymentconfigs_active_rollouts_duration_seconds counter",
-		"openshift_apps_deploymentconfigs_active_rollouts_duration_seconds{latest_version=\"1\",name=\"active\",namespace=\"test\",phase=\"running\"} 0",
-		"# HELP openshift_apps_deploymentconfigs_complete_rollouts_total Counts total complete rollouts",
-		"# TYPE openshift_apps_deploymentconfigs_complete_rollouts_total gauge",
-		"openshift_apps_deploymentconfigs_complete_rollouts_total{phase=\"available\"} 2",
-		"openshift_apps_deploymentconfigs_complete_rollouts_total{phase=\"cancelled\"} 1",
-		"openshift_apps_deploymentconfigs_complete_rollouts_total{phase=\"failed\"} 2",
-		"# HELP openshift_apps_deploymentconfigs_last_failed_rollout_time Tracks the time of last failure rollout per deployment config",
-		"# TYPE openshift_apps_deploymentconfigs_last_failed_rollout_time gauge",
-		"openshift_apps_deploymentconfigs_last_failed_rollout_time{latest_version=\"1\",name=\"failed\",namespace=\"test\"}",
+func TestRegistry(t *testing.T) {
+	expectedResponse := `# HELP openshift_apps_deploymentconfigs_active_rollouts_duration_seconds Tracks the active rollout duration in seconds
+# TYPE openshift_apps_deploymentconfigs_active_rollouts_duration_seconds counter
+openshift_apps_deploymentconfigs_active_rollouts_duration_seconds{latest_version="1",name="active",namespace="test",phase="running"} 0
+# HELP openshift_apps_deploymentconfigs_complete_rollouts_total Counts total complete rollouts
+# TYPE openshift_apps_deploymentconfigs_complete_rollouts_total gauge
+openshift_apps_deploymentconfigs_complete_rollouts_total{phase="available"} 2
+openshift_apps_deploymentconfigs_complete_rollouts_total{phase="cancelled"} 1
+openshift_apps_deploymentconfigs_complete_rollouts_total{phase="failed"} 2
+# HELP openshift_apps_deploymentconfigs_last_failed_rollout_time Tracks the time of last failure rollout per deployment config
+# TYPE openshift_apps_deploymentconfigs_last_failed_rollout_time gauge
+openshift_apps_deploymentconfigs_last_failed_rollout_time{latest_version="1",name="failed",namespace="test"} 42
+# HELP openshift_apps_deploymentconfigs_strategy_total Counts strategy usage
+# TYPE openshift_apps_deploymentconfigs_strategy_total gauge
+openshift_apps_deploymentconfigs_strategy_total{type="custom"} 0
+openshift_apps_deploymentconfigs_strategy_total{type="recreate"} 0
+openshift_apps_deploymentconfigs_strategy_total{type="rolling"} 0
+`
+
+	dcCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	rcCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	collector := appsCollector{
+		dcLister: appslisters.NewDeploymentConfigLister(dcCache),
+		rcLister: kcorelisters.NewReplicationControllerLister(rcCache),
+		nowFn:    defaultTimeNowFn,
 	}
-	lister := &fakeLister{
+
+	for _, dc := range []*appsv1.DeploymentConfig{} {
+		err := dcCache.Add(dc)
+		if err != nil {
+			t.Fatalf("unable to add dc %s: %v", dc.Name, err)
+		}
+	}
+
+	for _, rc := range []*corev1.ReplicationController{
 		mockRC("foo", 1, map[string]string{
 			appsv1.DeploymentStatusAnnotation:  string(appsv1.DeploymentStatusComplete),
 			appsv1.DeploymentVersionAnnotation: "1",
@@ -359,24 +443,43 @@ func TestLegacyRegistry(t *testing.T) {
 			appsv1.DeploymentStatusAnnotation:    string(appsv1.DeploymentStatusFailed),
 			appsv1.DeploymentVersionAnnotation:   "1",
 		}, 0, timeNow),
+	} {
+		err := rcCache.Add(rc)
+		if err != nil {
+			t.Fatalf("unable to add rc %s: %v", rc.Name, err)
+		}
 	}
 
-	ac := appsCollector{
-		lister: lister,
-		nowFn:  defaultTimeNowFn,
+	registry := metrics.NewKubeRegistry()
+	err := registry.Register(&collector)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	legacyregistry.MustRegister(&ac)
-
-	h := promhttp.HandlerFor(legacyregistry.DefaultGatherer, promhttp.HandlerOpts{ErrorHandling: promhttp.PanicOnError})
+	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.PanicOnError})
 	rw := &fakeResponseWriter{header: http.Header{}}
 	h.ServeHTTP(rw, &http.Request{})
 
 	respStr := rw.String()
 
-	for _, s := range expectedResponse {
-		if !strings.Contains(respStr, s) {
-			t.Errorf("expected string %s did not appear in %s", s, respStr)
+	var builder strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(respStr))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "openshift_apps_deploymentconfigs_") {
+			_, err := builder.WriteString(line)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = builder.WriteRune('\n')
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
+	}
+
+	d := cmp.Diff(expectedResponse, builder.String())
+	if len(d) > 0 {
+		t.Errorf("expected and received metrics differ: %s", d)
 	}
 }


### PR DESCRIPTION
Add `strategy_total` metric to identify usage for different strategies. Also fixed a bug in counting `last_failed_rollout_time`.

Requires:
- [x] unit test

/cc @soltysh 