### PR TITLE
Bug 1838372: Allow image push after postCommit script completes

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -2190,17 +2190,25 @@ func (bc *BuildController) createBuildSignaturePolicyData(config *configv1.Image
 		}
 	}
 
+	// Local containers-storage transport should always allow image "pull"
+	containersStorageScopes := make(signature.PolicyTransportScopes)
+	containersStorageScopes[""] = signature.PolicyRequirements{
+		signature.NewPRInsecureAcceptAnything(),
+	}
+
 	// Policies for image pull/push are set on a per-transport basis.
 	// This list will need to be updated if addtitional transports are used by the build pod.
 	// The following transports are currently available in openshift builds:
 	//
 	// 1. docker: a docker v2 registry (docker.io, quay.io, internal registry, etc.)
 	// 2. atomic: an ImageStreamTag reference - deprecated
+	// 3. containers-storage: local image storage
 	//
 	// See man skopeo(1) for the full list of supported transports.
 	policyObj.Transports = map[string]signature.PolicyTransportScopes{
-		"atomic": transportScopes,
-		"docker": transportScopes,
+		"atomic":             transportScopes,
+		"docker":             transportScopes,
+		"containers-storage": containersStorageScopes,
 	}
 
 	policyJSON, err := json.Marshal(policyObj)


### PR DESCRIPTION
Builds which use postCommit hooks run in a container that references the image digest sha
directly. To buildah these images are "pulled" using the containers-storage transport, i.e
from local storage. Previously, we did not set any policy for containers-storage transport,
which meant we fell back to the default policy. The default policy is "reject all" in clusters
with an `AllowedRegistries` setting in `image.config.openshift.io/cluster`.

This fixes the generated signature policy.json file in builds so that images in
containers-storage can always be "pulled" and pushed.