### PR TITLE
Basic docs for OCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
-##### openshift-controller-manager
+# OpenShift Controller Manager
 
-TODO: Add content
+The OpenShift Controller Manager (OCM) is comprised of multiple controllers, many of which
+correspond to a top-level OpenShift API object, watching for changes and acting accordingly.
+The controllers are generally organized by API group:
+
+- `apps.openshift.io` - OpenShift-specific workloads, like `DeploymentConfig`.
+- `build.openshift.io` - OpenShift `Builds` and `BuildConfigs`.
+- `image.openshift.io` - `ImageStreams` and `Images`.
+- `project.openshift.io` - Projects, OpenShift's wrapper for `Namespaces`.
+- `route.openshift.io` - OpenShift `Routes`, which provide similar capability to upstream `Ingress`
+  objects.
+- `template.openshift.io` - OpenShift `Templates` - a simple way to deploy applications.
+
+There are additional controllers which add OpenShift-specific capabilities to the cluster:
+
+- `authorization` - provides default service account role bindings for OpenShift projects.
+- `serviceaccounts` - manages secrets that allow images to be pulled and pushed from the
+  [OpenShift image registry](https://github.com/openshift/image-registry).
+- `unidling` - manages unidling of applications when inbound network traffic is detected. See the
+  [OpenShift docs](https://docs.openshift.com/container-platform/latest/applications/idling-applications.html#idle-unidling-applications_idling-applications)
+  for more information.
+
+## Metrics
+
+Many of the controllers expose metrics which are visible in the default OpenShift monitoring system
+(Prometheus). See [metrics](docs/metrics.md) for a detailed list of exposed metrics for each API
+group.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,32 @@
+# Openshift Controller Manager Metrics
+
+OCM exposes the following metrics to Prometheus for monitoring and analysis:
+
+## Apps
+
+| Name | Type | Labels | Description |
+| ---- | ---- | ------ | ----------- |
+| `openshift_apps_deploymentconfigs_active_rollouts_duration_seconds` | Counter | `namespace`, `name`, `phase`, `latest_version` | Tracks the active rollout duration in seconds |
+| `openshift_apps_deploymentconfigs_complete_rollouts_total` | Gauge | `phase` | Counts total complete rollouts |
+| `openshift_apps_deploymentconfigs_last_failed_rollout_time` | Gauge | `namespace`, `name`, `latest_version` | Tracks the active rollout duration in seconds |
+
+## Builds
+
+| Name | Type | Labels | Description |
+| ---- | ---- | ------ | ----------- |
+| `openshift_build_total` | Gauge | `phase`, `reason`, `strategy` | Counts builds by phase, reason, and strategy |
+| `openshift_build_active_time_seconds` | Gauge | `namespace`, `name`, `phase`, `reason`, `strategy` | Shows the last transition time in unix epoch for running builds by namespace, name, phase, reason, and strategy |
+
+## Image
+
+| Name | Type | Labels | Description |
+| ---- | ---- | ------ | ----------- |
+| `openshift_imagestreamcontroller_error_count` | Counter | `scheduled`, `registry`, `reason` | Counts number of failed image stream imports - both scheduled and not scheduled - per image registry and failure reason |
+| `openshift_imagestreamcontroller_success_count` | Counter | `scheduled`, `registry` | Counts successful image stream imports - both scheduled and not scheduled - per image registry |
+
+## Templates
+
+| Name | Type | Labels | Description |
+| ---- | ---- | ------ | ----------- |
+| `openshift_template_instance_completed_total` | Counter | `condition` | Counts completed TemplateInstance objects by condition |
+| `openshift_template_instance_active_age_seconds` | Histogram | No labels | Shows the instantaneous age distribution of active TemplateInstance objects |


### PR DESCRIPTION
Add basic `openshift-controller-manager` docs for users and contributors. This includes a README to
introduce the component, and a table of available metrics for monitoring.