### PR TITLE
Bug 1826183: Configure Build Pods to Merge CAs

### DIFF
--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -67,10 +67,10 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 			ServiceAccountName: serviceAccount,
 			Containers: []v1.Container{
 				{
-					Name:    DockerBuild,
-					Image:   bs.Image,
-					Command: []string{"openshift-docker-build"},
-					Env:     copyEnvVarSlice(containerEnv),
+					Name:  DockerBuild,
+					Image: bs.Image,
+					Args:  []string{"openshift-docker-build"},
+					Env:   copyEnvVarSlice(containerEnv),
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &privileged,
@@ -129,7 +129,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		gitCloneContainer := v1.Container{
 			Name:                     GitCloneContainer,
 			Image:                    bs.Image,
-			Command:                  []string{"openshift-git-clone"},
+			Args:                     []string{"openshift-git-clone"},
 			Env:                      copyEnvVarSlice(containerEnv),
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 			VolumeMounts: []v1.VolumeMount{
@@ -150,10 +150,10 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	}
 	if len(build.Spec.Source.Images) > 0 {
 		extractImageContentContainer := v1.Container{
-			Name:    ExtractImageContentContainer,
-			Image:   bs.Image,
-			Command: []string{"openshift-extract-image-content"},
-			Env:     copyEnvVarSlice(containerEnv),
+			Name:  ExtractImageContentContainer,
+			Image: bs.Image,
+			Args:  []string{"openshift-extract-image-content"},
+			Env:   copyEnvVarSlice(containerEnv),
 			// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 			SecurityContext: &v1.SecurityContext{
 				Privileged: &privileged,
@@ -184,7 +184,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		v1.Container{
 			Name:                     "manage-dockerfile",
 			Image:                    bs.Image,
-			Command:                  []string{"openshift-manage-dockerfile"},
+			Args:                     []string{"openshift-manage-dockerfile"},
 			Env:                      copyEnvVarSlice(containerEnv),
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 			VolumeMounts: []v1.VolumeMount{

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -77,10 +77,10 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 			ServiceAccountName: serviceAccount,
 			Containers: []corev1.Container{
 				{
-					Name:    StiBuild,
-					Image:   bs.Image,
-					Command: []string{"openshift-sti-build"},
-					Env:     copyEnvVarSlice(containerEnv),
+					Name:  StiBuild,
+					Image: bs.Image,
+					Args:  []string{"openshift-sti-build"},
+					Env:   copyEnvVarSlice(containerEnv),
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &privileged,
@@ -136,7 +136,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		gitCloneContainer := corev1.Container{
 			Name:                     GitCloneContainer,
 			Image:                    bs.Image,
-			Command:                  []string{"openshift-git-clone"},
+			Args:                     []string{"openshift-git-clone"},
 			Env:                      copyEnvVarSlice(containerEnv),
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			VolumeMounts: []corev1.VolumeMount{
@@ -157,10 +157,10 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	}
 	if len(build.Spec.Source.Images) > 0 {
 		extractImageContentContainer := corev1.Container{
-			Name:    ExtractImageContentContainer,
-			Image:   bs.Image,
-			Command: []string{"openshift-extract-image-content"},
-			Env:     copyEnvVarSlice(containerEnv),
+			Name:  ExtractImageContentContainer,
+			Image: bs.Image,
+			Args:  []string{"openshift-extract-image-content"},
+			Env:   copyEnvVarSlice(containerEnv),
 			// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: &privileged,
@@ -191,7 +191,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		corev1.Container{
 			Name:                     "manage-dockerfile",
 			Image:                    bs.Image,
-			Command:                  []string{"openshift-manage-dockerfile"},
+			Args:                     []string{"openshift-manage-dockerfile"},
 			Env:                      copyEnvVarSlice(containerEnv),
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			VolumeMounts: []corev1.VolumeMount{

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -32,9 +32,9 @@ const (
 	ConfigMapCertsMountPath              = "/var/run/configs/openshift.io/certs"
 	SecretBuildSourceBaseMountPath       = "/var/run/secrets/openshift.io/build"
 	SourceImagePullSecretMountPath       = "/var/run/secrets/openshift.io/source-image"
-	// ConfigMapBuildGlobalCAMountPath is the directory where the tls-ca-bundle.pem file will be mounted
-	// by the cluster CA operator
-	ConfigMapBuildGlobalCAMountPath = "/etc/pki/ca-trust/extracted/pem"
+	// ConfigMapBuildGlobalCAMountPath is the directory where cluster-wide trust bundle will be
+	// mounted in the build pod
+	ConfigMapBuildGlobalCAMountPath = "/var/run/configs/openshift.io/pki"
 
 	// ExtractImageContentContainer is the name of the container that will
 	// pull down input images and extract their content for input to the build.


### PR DESCRIPTION
* Mount the cluster PKI trust bundle in a neutral location. openshift/builder is
  responsible for copying this file to /etc/pki/ca-trust/source/anchors, then running
  `update-ca-trust extract`. This will generate trust bundles for all types of processes
  (email, TLS, JVMs, etc.).
* Use `Args` instead of `Command` when running builder image. This ensures the
  entrypoint script for openshift/builder is always invoked.