### PR TITLE
Add Build Result Counter Metric

### DIFF
--- a/pkg/build/buildutil/util.go
+++ b/pkg/build/buildutil/util.go
@@ -68,6 +68,10 @@ func IsTerminalPhase(phase buildv1.BuildPhase) bool {
 	return true
 }
 
+func IsBuildSuccessful(phase buildv1.BuildPhase) bool {
+	return phase == buildv1.BuildPhaseComplete
+}
+
 // BuildConfigSelector returns a label Selector which can be used to find all
 // builds for a BuildConfig.
 func BuildConfigSelector(name string) labels.Selector {

--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1554,7 +1554,9 @@ func (bc *BuildController) updateBuild(build *buildv1.Build, update *buildUpdate
 }
 
 func (bc *BuildController) handleBuildCompletion(build *buildv1.Build) {
+	metrics.IncrementBuildFinished(build)
 	bcName := sharedbuildutil.ConfigNameForBuild(build)
+	// empty bcName means that user submitted a raw Build object, with no associated BuildConfig
 	if len(strings.TrimSpace(bcName)) != 0 {
 		bc.enqueueBuildConfig(build.Namespace, bcName)
 		if err := common.HandleBuildPruning(bcName, build.Namespace, bc.buildLister, bc.buildConfigLister, bc.buildDeleter); err != nil {

--- a/pkg/build/metrics/prometheus/metrics_test.go
+++ b/pkg/build/metrics/prometheus/metrics_test.go
@@ -40,7 +40,7 @@ func (f *fakeResponseWriter) WriteHeader(statusCode int) {
 	f.statusCode = statusCode
 }
 
-func TestMetrics(t *testing.T) {
+func TestLegacyMetrics(t *testing.T) {
 	// went per line vs. a block of expected test in case assumptions on ordering are subverted, as well as defer on
 	// getting newlines right
 	expectedResponse := []string{
@@ -129,6 +129,194 @@ func TestMetrics(t *testing.T) {
 	}
 
 	legacyregistry.MustRegister(&bc)
+
+	h := promhttp.HandlerFor(legacyregistry.DefaultGatherer, promhttp.HandlerOpts{ErrorHandling: promhttp.PanicOnError})
+	rw := &fakeResponseWriter{header: http.Header{}}
+	h.ServeHTTP(rw, &http.Request{})
+
+	respStr := rw.String()
+
+	for _, s := range expectedResponse {
+		if !strings.Contains(respStr, s) {
+			t.Errorf("expected string %s did not appear in %s", s, respStr)
+		}
+	}
+}
+
+func TestBuildFinsishedCounter(t *testing.T) {
+	builds := []buildv1.Build{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-1",
+				Name:      "build-raw-docker-1",
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.DockerBuildStrategyType,
+						DockerStrategy: &buildv1.DockerBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseComplete,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-1",
+				Name:      "build-docker-1",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-docker",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.DockerBuildStrategyType,
+						DockerStrategy: &buildv1.DockerBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseComplete,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-1",
+				Name:      "build-docker-2",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-docker",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.DockerBuildStrategyType,
+						DockerStrategy: &buildv1.DockerBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseComplete,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-1",
+				Name:      "build-docker-3",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-docker",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.DockerBuildStrategyType,
+						DockerStrategy: &buildv1.DockerBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseFailed,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-1",
+				Name:      "build-docker-4",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-docker",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.DockerBuildStrategyType,
+						DockerStrategy: &buildv1.DockerBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseError,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-2",
+				Name:      "build-docker-1",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-docker",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.DockerBuildStrategyType,
+						DockerStrategy: &buildv1.DockerBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseComplete,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-2",
+				Name:      "build-src-1",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-src",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.SourceBuildStrategyType,
+						SourceStrategy: &buildv1.SourceBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseComplete,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-2",
+				Name:      "build-src-2",
+				Annotations: map[string]string{
+					buildv1.BuildConfigAnnotation: "build-src",
+				},
+			},
+			Spec: buildv1.BuildSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Strategy: buildv1.BuildStrategy{
+						Type:           buildv1.SourceBuildStrategyType,
+						SourceStrategy: &buildv1.SourceBuildStrategy{},
+					},
+				},
+			},
+			Status: buildv1.BuildStatus{
+				Phase: buildv1.BuildPhaseCancelled,
+			},
+		},
+	}
+	expectedResponse := []string{
+		"# HELP openshift_build_result_total [ALPHA] Counts the total number of finished builds across all namespaces by result and strategy",
+		"# TYPE openshift_build_result_total counter",
+		"openshift_build_result_total{result=\"failed\",strategy=\"docker\"} 2",
+		"openshift_build_result_total{result=\"failed\",strategy=\"source\"} 1",
+		"openshift_build_result_total{result=\"success\",strategy=\"docker\"} 4",
+		"openshift_build_result_total{result=\"success\",strategy=\"source\"} 1",
+	}
+
+	legacyregistry.MustRegister(buildResultCounter)
+
+	for _, build := range builds {
+		IncrementBuildFinished(&build)
+	}
 
 	h := promhttp.HandlerFor(legacyregistry.DefaultGatherer, promhttp.HandlerOpts{ErrorHandling: promhttp.PanicOnError})
 	rw := &fakeResponseWriter{header: http.Header{}}


### PR DESCRIPTION
Add new `openshift_build_result_total` counter metric to the build controller.
This monotonically increments when any build reaches a terminal state on the
cluster. To keep the cardinality of this metric low, only `result` and
`strategy` labels are applied.`result` can have the values "failed" or
"success". Strategy is the lowercased build strategy type (`docker`, `source`,
`custom`, and `jenkinspipeline`).

Unlike the metrics reported by openshift-state-metrics, this counter will
continue to increase even if the build object is deleted by the build
controller's retention history feature.