### PR TITLE
Node Image Storage (PoC)

### DIFF
--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -210,8 +210,8 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
 	setupContainersConfigs(build, pod)
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
-	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
-	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds
+	setupContainersStorage(pod, &pod.Spec.Containers[0])
+	setupContainersNodeStorage(pod, &pod.Spec.Containers[0])
 	setupBlobCache(pod)
 	return pod, nil
 }

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -90,13 +90,14 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	// blobs content cache
 	// global CA injection configmap
 	// node pull secrets
-	if len(container.VolumeMounts) != 12 {
-		t.Fatalf("Expected 12 volumes in container, got %d", len(container.VolumeMounts))
+	if len(container.VolumeMounts) != 13 {
+		t.Fatalf("Expected 13 volumes in container, got %d", len(container.VolumeMounts))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
 	}
-	expectedMounts := []string{buildutil.NodePullSecretsPath,
+	expectedMounts := []string{
+		buildutil.NodePullSecretsPath,
 		buildutil.BuildWorkDirMount,
 		buildutil.BuildBlobsMetaCache,
 		DockerPushSecretMountPath,
@@ -106,7 +107,8 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		ConfigMapBuildSystemConfigsMountPath,
 		ConfigMapCertsMountPath,
 		ConfigMapBuildGlobalCAMountPath,
-		"/var/lib/containers/storage",
+		containersStoragePath,
+		containersAdditionalStoragePath,
 		buildutil.BuildBlobsContentCache,
 	}
 	for i, expected := range expectedMounts {
@@ -115,8 +117,8 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 13 {
-		t.Fatalf("Expected 13 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 14 {
+		t.Fatalf("Expected 14 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if !kapihelper.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -217,8 +217,8 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
 	setupContainersConfigs(build, pod)
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
-	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
-	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds
+	setupContainersStorage(pod, &pod.Spec.Containers[0])
+	setupContainersNodeStorage(pod, &pod.Spec.Containers[0])
 	setupBlobCache(pod)
 	return pod, nil
 }

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -130,8 +130,8 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	// container storage
 	// blobs content cache
 	// global CA injection configmap
-	if len(container.VolumeMounts) != 12 {
-		t.Fatalf("Expected 12 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
+	if len(container.VolumeMounts) != 13 {
+		t.Fatalf("Expected 13 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
 	}
 	expectedMounts := []string{buildutil.NodePullSecretsPath,
 		buildutil.BuildWorkDirMount,
@@ -143,7 +143,8 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 		ConfigMapBuildSystemConfigsMountPath,
 		ConfigMapCertsMountPath,
 		ConfigMapBuildGlobalCAMountPath,
-		"/var/lib/containers/storage",
+		containersStoragePath,
+		containersAdditionalStoragePath,
 		buildutil.BuildBlobsContentCache,
 	}
 	for i, expected := range expectedMounts {
@@ -152,8 +153,8 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 13 {
-		t.Fatalf("Expected 13 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 14 {
+		t.Fatalf("Expected 14 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -463,7 +463,7 @@ func setupContainersStorage(pod *corev1.Pod, container *corev1.Container) {
 }
 
 // setupContainersNodeStorage borrows the appropriate storage directories from the node so
-// that we can share layers that we're using with the node, as a additional read-only
+// that we can share layers that we're using with the node, as an additional read-only
 // mount point.
 func setupContainersNodeStorage(pod *corev1.Pod, container *corev1.Container) {
 	exists := false


### PR DESCRIPTION
This pull-request implements the changes described by [Node Cache for Builds enhancement proposal](https://github.com/openshift/enhancements/blob/master/enhancements/builds/node-cache-for-builds.md), bringing read-only access to node images for builds. Please consider the document for full details.

The modifications were mostly in `setupContainersNodeStorage` and `setupContainersStorage` in order to mount volumes as described bellow.

## Volumes and Mounts

In the following table you can see how the volumes are mounted on build pods.

| Name                   | Node (`hostPath`)             | Pod                           | Mode |
|------------------------|-------------------------------|-------------------------------|------|
| node-storage-root      | `/var/lib/containers/storage` | `/var/lib/shared`             | `ro` |
| container-storage-root | None (`EmptyDir{}`)           | `/var/lib/containers/storage` | `rw` |

The mount location `/var/lib/shared` is chosen due the existing [configuration in openshift/builder](https://github.com/openshift/builder/blob/00f9e90d06c3ac8aeac9642e2af3221eb7f0b6e1/imagecontent/etc/containers/storage.conf#L22). This location could be changed later on, however, that's also the default location for `buildah` upstream.

## OpenShift-Builder

With [current `containers/storage`](https://github.com/openshift/builder/blob/00f9e90d06c3ac8aeac9642e2af3221eb7f0b6e1/go.mod#L10), it will end-up with permission issues on trying to access node layers. Like the following example:

```
error: build error: Failed to push image: error copying layers and metadata from "containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.imagestore=/var/lib/shared]image-registry.openshift-image-registry.svc:5000/otaviof/rails-ex:latest" to "docker://image-registry.openshift-image-registry.svc:5000/otaviof/rails-ex:latest": Error reading blob sha256:2bf094d88b12300b2226c4c24f80533dec869141b52b88f706843329c4f54b1d: error reading blob from source image "containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.imagestore=/var/lib/shared]image-registry.openshift-image-registry.svc:5000/otaviof/rails-ex:latest": not allowed to update mount locations for layers at "/var/run/containers/storage/overlay-layers/mountpoints.json": called a write method on a read-only store
```

Therefore, this pull-request is linked with [PR #164 in openshift-builder](https://github.com/openshift/builder/pull/164).

## Testing

With both images for openshift-controller-manager and openshift-builder (based on [PR #164](https://github.com/openshift/builder/pull/164)), create a new `BuildConfig` object with:

```bash
oc new-app --name=nodejs-ex https://github.com/sclorg/nodejs-ex.git
```

Then, add a distinct label in one of the cluster nodes. For instance:

```bash
oc label nodes ip-10-0-139-172.ec2.internal test-build=true
```

And edit `BuilldConfig` to use the same label:

```bash
oc patch buildconfig/nodejs-ex --patch='{ "spec": { "nodeSelector": { "test-build": "true" } } }'
```

Finally, the `nodejs-ex` build can be started:

```bash
oc start-build nodejs-ex
```