### PR TITLE
Bug 1820075: Reflect route status to ingress status

### DIFF
--- a/pkg/cmd/controller/ingress.go
+++ b/pkg/cmd/controller/ingress.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	networkingclient "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
 
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/openshift-controller-manager/pkg/route/ingress"
@@ -17,10 +18,15 @@ func RunIngressToRouteController(ctx *ControllerContext) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	networkingClient, err := networkingclient.NewForConfig(clientConfig)
+	if err != nil {
+		return false, err
+	}
 
 	controller := ingress.NewController(
 		coreClient,
 		routeClient,
+		networkingClient,
 		ctx.KubernetesInformers.Networking().V1beta1().Ingresses(),
 		ctx.KubernetesInformers.Core().V1().Secrets(),
 		ctx.KubernetesInformers.Core().V1().Services(),


### PR DESCRIPTION
#### ingress: Rename client to routeClient

* `pkg/route/ingress/ingress.go` (`Controller`): Rename "client" to "routeClient".
(`NewController`, `sync`):
* `pkg/route/ingress/ingress_test.go` (`TestController_stabilizeAfterCreate`, `TestController_sync`): Use the new field name.


#### ingress: Rename fake route clientset

* `pkg/route/ingress/ingress_test.go`: Rename import of the fake clientset for the route API to "routev1fake".
(`TestController_stabilizeAfterCreate`, `TestController_sync`): Rename the fake clientset for the route API from "kc" to "routeClientset".  Rename "actions" to "routeActions".


#### ingress: wantCreates, wantPatches, wantDeletes

* `pkg/route/ingress/ingress_test.go` (`TestController_sync`): Rename `wantCreates` to `wantRouteCreates`, `wantPatches` to `wantRoutePatches`, and `wantDeletes` to `wantRouteDeletes`.


#### Reflect route status to ingress status

* `pkg/cmd/controller/ingress.go` (`RunIngressToRouteController`): Pass ingress client to `ingress.NewController`.
* `pkg/route/ingress/ingress.go` (`Controller`): Add `ingressClient` field.
(`NewController`): Add `ingressClient` parameter.  Use the new parameter to set the `Controller` field.
(`sync`): Reflect the canonical hostname from routes that match the ingress to the ingress's status.
* `pkg/route/ingress/ingress_test.go` (`TestController_stabilizeAfterCreate`): Add fake clientset for the networking API.  Use this fake clientset to initialize the controller.
(`TestController_sync`): Add `wantIngressUpdates` to the test inputs.  Add fake clientset for the networking API.  Use `wantIngressUpdates` in new test cases for ingress status updates.  Use the fake networking clientset to initialize the controller and to verify the new tests cases.

----

Depends on https://github.com/openshift/openshift-apiserver/pull/129 and https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/169.