### PR TITLE
Bug 1849176: Revert "Remove unnecessary yum install"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+RUN yum install -y gpgme-devel libassuan-devel
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+RUN yum install -y gpgme-devel libassuan-devel
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables


### PR DESCRIPTION
ART builds for golang 1.12 do not include `gpgme-devel` and
`libassuan-devel`. Removing caused ART builds to fail.

Run `yum install` commands before setting the WORKDIR, because
the working directory does not exist in the container until
the COPY directive executes.