### PR TITLE
BUILD-187: Detect if image trigger ID was cleared

### DIFF
--- a/pkg/build/metrics/prometheus/metrics.go
+++ b/pkg/build/metrics/prometheus/metrics.go
@@ -37,6 +37,7 @@ var (
 		[]string{"namespace", "name", "phase", "reason", "strategy"},
 		nil,
 	)
+
 	bc             = buildCollector{}
 	cancelledPhase = string(buildv1.BuildPhaseCancelled)
 	completePhase  = string(buildv1.BuildPhaseComplete)

--- a/pkg/build/metrics/prometheus/metrics_test.go
+++ b/pkg/build/metrics/prometheus/metrics_test.go
@@ -40,7 +40,7 @@ func (f *fakeResponseWriter) WriteHeader(statusCode int) {
 	f.statusCode = statusCode
 }
 
-func TestMetrics(t *testing.T) {
+func TestBuildMetrics(t *testing.T) {
 	// went per line vs. a block of expected test in case assumptions on ordering are subverted, as well as defer on
 	// getting newlines right
 	expectedResponse := []string{


### PR DESCRIPTION
Detect if the lastTriggeredImageID was cleared in a BuildConfig.
If an update cleared the last triggered image, record a warning event.

A metric and associated alert were considered to better inform users
that deprecated behavior is being triggered. However, this was rejected
because the metric would require unbound time series cardinality.

The behavior that triggers builds off of `spec` will be removed in [BUILD-188](https://issues.redhat.com/browse/BUILD-188) [1].

[1] https://issues.redhat.com/browse/BUILD-188