### PR TITLE
ingress-to-route: add support for dest ca cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/openshift-controller-manager/openshift-controller-manager /usr/bin/
 LABEL io.k8s.display-name="OpenShift Controller Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -747,9 +747,11 @@ func tlsConfigForIngress(
 	// Re-Encrypt: May have cert
 	// Passthrough: Must not have cert
 	terminationPolicy := terminationPolicyForIngress(ingress)
+	destinationCACertificate := destinationCACertificateForIngress(ingress)
 	tlsConfig := &routev1.TLSConfig{
 		Termination:                   terminationPolicy,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		DestinationCACertificate:      destinationCACertificate,
 	}
 	if terminationPolicy != routev1.TLSTerminationPassthrough && potentiallyNilTLSSecret != nil {
 		tlsConfig.Certificate = string(potentiallyNilTLSSecret.Data[corev1.TLSCertKey])
@@ -800,6 +802,7 @@ func tlsSecretIfValid(ingress *networkingv1beta1.Ingress, rule *networkingv1beta
 }
 
 var terminationPolicyAnnotationKey = routev1.GroupName + "/termination"
+var destinationCACertificateAnnotationKey = routev1.GroupName + "/destinationCACertificate"
 
 func terminationPolicyForIngress(ingress *networkingv1beta1.Ingress) routev1.TLSTerminationType {
 	switch {
@@ -810,4 +813,10 @@ func terminationPolicyForIngress(ingress *networkingv1beta1.Ingress) routev1.TLS
 	default:
 		return routev1.TLSTerminationEdge
 	}
+}
+
+func destinationCACertificateForIngress(ingress *networkingv1beta1.Ingress) string {
+
+	return ingress.Annotations[destinationCACertificateAnnotationKey]
+
 }


### PR DESCRIPTION
This PR adds support for `route.openshift.io/v1/Route.spec.tls.destinationCACertificate` [[1](https://docs.openshift.com/container-platform/4.6/rest_api/network_apis/route-route-openshift-io-v1.html)] as the following Ingress Annotation

```
route.openshift.io/destinationCACertificate
```

This is needed to support reencrypt termination where the underlying pod has a self signed cert [[2](https://access.redhat.com/solutions/4601031)].

With this PR the following works

```yaml
kind: Ingress
apiVersion: networking.k8s.io/v1beta1
metadata:
  annotations:
    route.openshift.io/destinationCACertificate: |
      -----BEGIN CERTIFICATE-----
      <snip>
      -----END CERTIFICATE-----
    route.openshift.io/termination: reencrypt
```

I've tested this in the latest Code Ready Containers (v1.20 at time of writing), which has an OpenShift cluster version of 4.6.6. The code modifications were tested using a cherry pick of the changes in this PR onto a [release-4.6 based branch](https://github.com/mergetb/openshift-controller-manager/tree/release-4.6-ingress-destination-ca).

The change to the Dockerfile is to make it possible for folks outside of RH to build the container. If this is not desired, or there is a better publicly accessible alternative I'm happy to remove or update that change.

[1] https://docs.openshift.com/container-platform/4.6/rest_api/network_apis/route-route-openshift-io-v1.htm
[2] https://access.redhat.com/solutions/4601031