### PR TITLE
mirror idling annotations to endpoint slices

### DIFF
--- a/pkg/cmd/controller/unidling.go
+++ b/pkg/cmd/controller/unidling.go
@@ -29,6 +29,7 @@ func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 	}
 
 	coreClient := ctx.ClientBuilder.ClientOrDie(infraUnidlingControllerServiceAccountName).CoreV1()
+	discoveryClient := ctx.ClientBuilder.ClientOrDie(infraUnidlingControllerServiceAccountName).DiscoveryV1beta1()
 	controller := unidlingcontroller.NewUnidlingController(
 		scaleClient,
 		ctx.RestMapper,
@@ -36,6 +37,7 @@ func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 		coreClient,
 		appsClient.AppsV1(),
 		coreClient,
+		discoveryClient,
 		resyncPeriod,
 	)
 


### PR DESCRIPTION
Kubernetes EndpointSlices offer a more scalable and extensible
alternative to Endpoints, but it doesn´t mean that Endpoints are
going to be replaced.

Openshift uses Endpoints to implement the idling feature, adding
annotations on the Endpoints objects. However, some of the consumers
of this annotations need to migrate to Endpoint Slices to use
some new features, like dual stack.

In order to simplify the migration to endpoint slices keeping the
same functionality with the idling feature, we can mirror the
endpoints idling annotations to the corresponding slices.

Signed-off-by: Antonio Ojea <aojea@redhat.com>