### PR TITLE
remove use of BUILD_ISOLATION env var (no longer inspected in openshift/builder)

### DIFF
--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -65,7 +65,6 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		"BUILD_REGISTRIES_DIR_PATH":   "",
 		"BUILD_SIGNATURE_POLICY_PATH": "",
 		"BUILD_STORAGE_CONF_PATH":     "",
-		"BUILD_ISOLATION":             "",
 		"BUILD_STORAGE_DRIVER":        "",
 		"BUILD_BLOBCACHE_DIR":         "",
 	}

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -102,7 +102,6 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 		"BUILD_SIGNATURE_POLICY_PATH": "",
 		"BUILD_STORAGE_CONF_PATH":     "",
 		"BUILD_STORAGE_DRIVER":        "",
-		"BUILD_ISOLATION":             "",
 		"BUILD_BLOBCACHE_DIR":         "",
 	}
 	if !rootAllowed {

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -454,7 +454,6 @@ func setupContainersStorage(pod *corev1.Pod, container *corev1.Container) {
 		},
 	)
 	container.Env = append(container.Env, corev1.EnvVar{Name: "BUILD_STORAGE_DRIVER", Value: "overlay"})
-	container.Env = append(container.Env, corev1.EnvVar{Name: "BUILD_ISOLATION", Value: "chroot"})
 }
 
 // setupContainersNodeStorage borrows the appropriate storage directories from the node so
@@ -488,7 +487,6 @@ func setupContainersNodeStorage(pod *corev1.Pod, container *corev1.Container) {
 		},
 	)
 	container.Env = append(container.Env, corev1.EnvVar{Name: "BUILD_STORAGE_DRIVER", Value: "overlay"})
-	container.Env = append(container.Env, corev1.EnvVar{Name: "BUILD_ISOLATION", Value: "chroot"})
 }
 
 func addVolumeMountToContainers(conts []corev1.Container, mount corev1.VolumeMount) []corev1.Container {


### PR DESCRIPTION
manual pick of https://github.com/openshift/openshift-controller-manager/pull/160 required

tests won't pass until https://github.com/openshift/builder/pull/207 merges

/assign @bparees 

@adambkaplan @jupierce FYI