### PR TITLE
Bug 1911470: Creating secrets do access registry through routes

### DIFF
--- a/pkg/cmd/controller/serviceaccount.go
+++ b/pkg/cmd/controller/serviceaccount.go
@@ -78,6 +78,7 @@ func RunServiceAccountPullSecretsController(ctx *ControllerContext) (bool, error
 	go serviceaccountcontrollers.NewDockerRegistryServiceController(
 		ctx.KubernetesInformers.Core().V1().Secrets(),
 		ctx.KubernetesInformers.Core().V1().Services(),
+		ctx.ConfigInformers.Config().V1().Images(),
 		kc,
 		dockerRegistryControllerOptions,
 	).Run(10, ctx.Stop)


### PR DESCRIPTION
This commits adds registry external routes to created docker
configuration secrets.

It hooks the controller manager into Image config changes.