### PR TITLE
Bug 1900989: unidling: switch away from endpoints to the service

### DIFF
--- a/pkg/cmd/controller/unidling.go
+++ b/pkg/cmd/controller/unidling.go
@@ -34,6 +34,7 @@ func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 		ctx.RestMapper,
 		coreClient,
 		coreClient,
+		coreClient,
 		appsClient.AppsV1(),
 		coreClient,
 		resyncPeriod,

--- a/pkg/unidling/controller/unidling_controller.go
+++ b/pkg/unidling/controller/unidling_controller.go
@@ -66,19 +66,20 @@ func (c *lastFiredCache) AddIfNewer(info types.NamespacedName, newLastFired time
 }
 
 type UnidlingController struct {
-	controller         cache.Controller
-	scaleNamespacer    scale.ScalesGetter
-	mapper             meta.RESTMapper
-	servicesNamespacer corev1client.ServicesGetter
-	queue              workqueue.RateLimitingInterface
-	lastFiredCache     *lastFiredCache
+	controller          cache.Controller
+	scaleNamespacer     scale.ScalesGetter
+	mapper              meta.RESTMapper
+	endpointsNamespacer corev1client.EndpointsGetter
+	servicesNamespacer  corev1client.ServicesGetter
+	queue               workqueue.RateLimitingInterface
+	lastFiredCache      *lastFiredCache
 
 	// TODO: remove these once we get the scale-source functionality in the scale endpoints
 	dcNamespacer appstypedclient.DeploymentConfigsGetter
 	rcNamespacer corev1client.ReplicationControllersGetter
 }
 
-func NewUnidlingController(scaleNS scale.ScalesGetter, mapper meta.RESTMapper, servicesNS corev1client.ServicesGetter, evtNS corev1client.EventsGetter,
+func NewUnidlingController(scaleNS scale.ScalesGetter, mapper meta.RESTMapper, endptsNS corev1client.EndpointsGetter, servicesNS corev1client.ServicesGetter, evtNS corev1client.EventsGetter,
 	dcNamespacer appstypedclient.DeploymentConfigsGetter, rcNamespacer corev1client.ReplicationControllersGetter,
 	resyncPeriod time.Duration) *UnidlingController {
 	fieldSet := fields.Set{}
@@ -86,10 +87,11 @@ func NewUnidlingController(scaleNS scale.ScalesGetter, mapper meta.RESTMapper, s
 	fieldSelector := fieldSet.AsSelector()
 
 	unidlingController := &UnidlingController{
-		scaleNamespacer:    scaleNS,
-		mapper:             mapper,
-		servicesNamespacer: servicesNS,
-		queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "unidling"),
+		scaleNamespacer:     scaleNS,
+		mapper:              mapper,
+		endpointsNamespacer: endptsNS,
+		servicesNamespacer:  servicesNS,
+		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "unidling"),
 		lastFiredCache: &lastFiredCache{
 			items: make(map[types.NamespacedName]time.Time),
 		},
@@ -391,6 +393,46 @@ func (c *UnidlingController) handleRequest(info types.NamespacedName, lastFired 
 
 	if _, err = c.servicesNamespacer.Services(info.Namespace).Update(context.TODO(), targetService, metav1.UpdateOptions{}); err != nil {
 		return true, fmt.Errorf("unable to update/remove idle annotations from %s/%s: %v", info.Namespace, info.Name, err)
+	}
+
+	// oc idle still annotates endpoints for backwards
+	// compatibilty. We need to remove any idled annotations on
+	// the endpoints.
+
+	// fetch the endpoints in question
+	targetEndpoints, err := c.endpointsNamespacer.Endpoints(info.Namespace).Get(context.TODO(), info.Name, metav1.GetOptions{})
+	if err != nil {
+		return true, fmt.Errorf("unable to retrieve endpoints: %v", err)
+	}
+
+	// make sure we actually were idled...
+	idledTimeRaw, wasIdled = targetEndpoints.Annotations[unidlingapi.IdledAtAnnotation]
+	if !wasIdled {
+		klog.V(5).Infof("UnidlingController received a NeedPods event for a service that was not idled, ignoring")
+		return false, nil
+	}
+
+	// ...and make sure this request was to wake up from the most recent idling, and not a previous one
+	idledTime, err = time.Parse(time.RFC3339, idledTimeRaw)
+	if err != nil {
+		// retrying here won't help, we're just stuck as idle since we can't get parse the idled time
+		return false, fmt.Errorf("unable to check idled-at time: %v", err)
+	}
+	if lastFired.Before(idledTime) {
+		klog.V(5).Infof("UnidlingController received an out-of-date NeedPods event, ignoring")
+		return false, nil
+	}
+
+	_, unidledAnnotation := targetEndpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
+	_, idledAtAnnotation := targetEndpoints.Annotations[unidlingapi.IdledAtAnnotation]
+
+	if unidledAnnotation || idledAtAnnotation {
+		delete(targetEndpoints.Annotations, unidlingapi.UnidleTargetAnnotation)
+		delete(targetEndpoints.Annotations, unidlingapi.IdledAtAnnotation)
+
+		if _, err = c.endpointsNamespacer.Endpoints(info.Namespace).Update(context.TODO(), targetEndpoints, metav1.UpdateOptions{}); err != nil {
+			return true, fmt.Errorf("unable to update/remove idle annotations from %s/%s: %v", info.Namespace, info.Name, err)
+		}
 	}
 
 	return false, nil

--- a/pkg/unidling/controller/unidling_controller_test.go
+++ b/pkg/unidling/controller/unidling_controller_test.go
@@ -225,11 +225,12 @@ func TestControllerHandlesStaleEvents(t *testing.T) {
 	nowTime := time.Now().Truncate(time.Second)
 	fakeClient, fakeDeployClient, fakeScaleClient, mapper, res := prepFakeClient(t, nowTime)
 	controller := &UnidlingController{
-		mapper:             mapper,
-		servicesNamespacer: fakeClient.CoreV1(),
-		rcNamespacer:       fakeClient.CoreV1(),
-		dcNamespacer:       fakeDeployClient.AppsV1(),
-		scaleNamespacer:    fakeScaleClient,
+		mapper:              mapper,
+		endpointsNamespacer: fakeClient.CoreV1(),
+		servicesNamespacer:  fakeClient.CoreV1(),
+		rcNamespacer:        fakeClient.CoreV1(),
+		dcNamespacer:        fakeDeployClient.AppsV1(),
+		scaleNamespacer:     fakeScaleClient,
 	}
 
 	retry, err := controller.handleRequest(types.NamespacedName{
@@ -282,11 +283,12 @@ func TestControllerIgnoresAlreadyScaledObjects(t *testing.T) {
 	fakeClient, fakeDeployClient, fakeScaleClient, mapper, res := prepFakeClient(t, idledTime, baseScales...)
 
 	controller := &UnidlingController{
-		mapper:             mapper,
-		scaleNamespacer:    fakeScaleClient,
-		servicesNamespacer: fakeClient.CoreV1(),
-		rcNamespacer:       fakeClient.CoreV1(),
-		dcNamespacer:       fakeDeployClient.AppsV1(),
+		mapper:              mapper,
+		endpointsNamespacer: fakeClient.CoreV1(),
+		scaleNamespacer:     fakeScaleClient,
+		servicesNamespacer:  fakeClient.CoreV1(),
+		rcNamespacer:        fakeClient.CoreV1(),
+		dcNamespacer:        fakeDeployClient.AppsV1(),
 	}
 
 	retry, err := controller.handleRequest(types.NamespacedName{
@@ -395,11 +397,12 @@ func TestControllerUnidlesProperly(t *testing.T) {
 	fakeClient, fakeDeployClient, fakeScaleClient, mapper, res := prepFakeClient(t, nowTime.Add(-10*time.Second), baseScales...)
 
 	controller := &UnidlingController{
-		mapper:             mapper,
-		servicesNamespacer: fakeClient.CoreV1(),
-		rcNamespacer:       fakeClient.CoreV1(),
-		dcNamespacer:       fakeDeployClient.AppsV1(),
-		scaleNamespacer:    fakeScaleClient,
+		mapper:              mapper,
+		endpointsNamespacer: fakeClient.CoreV1(),
+		servicesNamespacer:  fakeClient.CoreV1(),
+		rcNamespacer:        fakeClient.CoreV1(),
+		dcNamespacer:        fakeDeployClient.AppsV1(),
+		scaleNamespacer:     fakeScaleClient,
 	}
 
 	retry, err := controller.handleRequest(types.NamespacedName{
@@ -768,11 +771,12 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 	for _, test := range tests {
 		fakeClient, fakeDeployClient, fakeScaleClient, mapper := prepareFakeClientForFailureTest(test)
 		controller := &UnidlingController{
-			mapper:             mapper,
-			servicesNamespacer: fakeClient.CoreV1(),
-			rcNamespacer:       fakeClient.CoreV1(),
-			dcNamespacer:       fakeDeployClient.AppsV1(),
-			scaleNamespacer:    fakeScaleClient,
+			mapper:              mapper,
+			endpointsNamespacer: fakeClient.CoreV1(),
+			servicesNamespacer:  fakeClient.CoreV1(),
+			rcNamespacer:        fakeClient.CoreV1(),
+			dcNamespacer:        fakeDeployClient.AppsV1(),
+			scaleNamespacer:     fakeScaleClient,
 		}
 
 		var retry bool


### PR DESCRIPTION
Previously idle annotations were added to endpoints. In 4.6 the router
switched to watching endpointslices which don't have the idle
annotation. There was some upstream PRs/discussion to automatically
propagate existing annotations from endpoints to endpointslices:

  https://github.com/kubernetes/kubernetes/pull/98116

As that was a non-starter we changed oc/idle to annotate the service
(and the endpoints for backwards compatibility). In the router we are
already watching service and and when we get endpoint changes we now
check for the idle annotation on the service. If it is present we
write the cluster-ip address into the haproxy.config as we previously
did prior to switching to endpointslices. We watch endpointslices for 
dual-stack and IPv6 support.

This change means that undiling needs to watch for services with idle
annotations as opposed to endpoints. Switch the unidling controller to 
look for idle annotations on the service.

Requires:
- https://github.com/openshift/oc/pull/720
- https://github.com/openshift/router/pull/225
- ~https://github.com/openshift/sdn/pull/252~
- https://github.com/openshift/openshift-apiserver/pull/180
- https://github.com/openshift/origin/pull/25844
- https://github.com/openshift/origin/pull/25847


TODO: amend  origin test (https://github.com/openshift/origin/pull/25847)  to exercise idle/unidle via a route and not just the service.