### PR TITLE
ingress: Migrate to networking.k8s.io/v1

### DIFF
--- a/pkg/cmd/controller/ingress.go
+++ b/pkg/cmd/controller/ingress.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
-	networkingclient "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
+	networkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
 
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/openshift-controller-manager/pkg/route/ingress"
@@ -18,7 +18,7 @@ func RunIngressToRouteController(ctx *ControllerContext) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	networkingClient, err := networkingclient.NewForConfig(clientConfig)
+	networkingClient, err := networkingv1.NewForConfig(clientConfig)
 	if err != nil {
 		return false, err
 	}
@@ -27,7 +27,8 @@ func RunIngressToRouteController(ctx *ControllerContext) (bool, error) {
 		coreClient,
 		routeClient,
 		networkingClient,
-		ctx.KubernetesInformers.Networking().V1beta1().Ingresses(),
+		ctx.KubernetesInformers.Networking().V1().Ingresses(),
+		ctx.KubernetesInformers.Networking().V1().IngressClasses(),
 		ctx.KubernetesInformers.Core().V1().Secrets(),
 		ctx.KubernetesInformers.Core().V1().Services(),
 		ctx.RouteInformers.Route().V1().Routes(),


### PR DESCRIPTION
Update the ingress-to-route controller and unit tests to use the `networking.k8s.io/v1` API, implement IngressClass, and migrate routes created using older ingress API versions.

* `pkg/cmd/controller/ingress.go`: Update to import and use `networking/v1` packages.
(`RunIngressToRouteController`): Pass ingressclass client to `NewController`.
* `pkg/route/ingress/ingress.go`: Update to import and use `networking/v1` packages.
(`Controller`): Add `ingressclassLister` field.
(`NewController`): Add parameter for `ingressclasses` informer.  Use it to get `ingressclassLister`.
(`sync`): Check the ingress's `kubernetes.io/ingress.class` annotation and `spec.ingressClassName` field.  If an ingressclass is specified, look it up and check its `spec.controller` field value.  If the ingress specifies an ingressclass that does not specify the `openshift.io/ingress-to-route` ingressclass, ignore the ingress.  When patching an ingress, replace the existing `ownerReferences` field value in case the API version has changed.
(`validOwnerRefAPIVersions`): New variable.
(`hasIngressOwnerRef`): Use `validOwnerRefAPIVersions` to verify that the owner reference specifies some recognized API version.
(`newRouteForIngress`): Update to use the ingress's `spec.backend.service` field to get the target service.  Use the `networking.k8s.io/v1` API version in the returned route's owner reference.
(`routeMatchesIngress`): Update to use the ingress's `spec.backend.service` field.  Verify that the route's owner reference uses the `networking.k8s.io/v1` API version.
(`targetPortForService`): Replace the ingress path parameter with an ingress service backend parameter.
* `pkg/route/ingress/ingress_test.go`: Update to use and import `networking/v1` packages.
(`ingressclassLister`): New type.  Implement a fake ingressclass lister.
(`List`, `Get`): New methods for `ingressclassLister`.
(`complexIngress`): Update to the v1 API.
(`TestController_stabilizeAfterCreate`): Use a fake ingressclass lister.
(`TestController_sync`): Define fake ingressclass lister with an ingressclass that specifies the OpenShift ingress controller.  Update ingresses in test cases to the v1 API.  Update test cases to expect the controller to patch `ownerReferences`.  Add test cases: "ignores ingress with third-party ingressclass", "ignores ingress with unsupported path type", "create route - default ingresscontroller", "create route - custom ingresscontroller", "no-op - ignore route created for an ingress with a third-party class", and "update route with old owner reference".  Augment the "create route" test case to verify correct behavior for the implemented path types.