### PR TITLE
BUILD-433: Run builds in user namespaces without seccomp if BUILD_PRIVILEGED=false

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1321,7 +1321,7 @@ func (bc *BuildController) createBuildPod(build *buildv1.Build) (*buildUpdate, e
 			return update, fmt.Errorf("could not find registry config for build: %v", err)
 		}
 		if !hasRegistryConf {
-			// Create the registry config ConfigMap to mount the regsitry config to the existing build pod
+			// Create the registry config ConfigMap to mount the registry config to the existing build pod
 			update, err = bc.createBuildSystemConfConfigMap(build, existingPod, update)
 			if err != nil {
 				return update, err


### PR DESCRIPTION
In the build controller, we never actually called `setupContainersNodeStorage()`, so remove it, and stop setting the environment variable to force storage to use the overlay driver, which currently requires privileges, leaning on https://github.com/openshift/builder/pull/220 and https://github.com/openshift/builder/pull/291 to have the builder container figure that out for itself.

~Make the mode which we apply to secret and configuration map volumes in build pods something that the build controller can pass down to its helper functions, so that it can be adjusted based on the strategy.  Continue to default them to 0600.~

Set the seccomp profile for build pods to "unconfined", since we depend on `unshare()` and CRI-O is attempting to move away from allowing it to be used in its default seccomp profile.

When the Build object's environment includes "BUILD_PRIVILEGED=false" or "BUILD_PRIVILEGED=0":
* turn off the "privileged" flag for build pods
* set "io.openshift.builder=" and "io.kubernetes.cri-o.Devices=/dev/fuse:rwm" annotations
* set "io.kubernetes.cri-o.userns-mode=auto:size=65536"