### PR TITLE
Bug 1935165: fixed LANG for the builder container

### DIFF
--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -55,7 +55,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 
 	containerEnv := []corev1.EnvVar{
 		{Name: "BUILD", Value: string(data)},
-		{Name: "LANG", Value: "en_US.utf8"},
+		{Name: "LANG", Value: "C.utf8"},
 	}
 
 	if build.Spec.Source.Git != nil {

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -100,7 +100,7 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	buildJSON, _ := runtime.Encode(customBuildEncodingCodecFactory.LegacyCodec(buildv1.GroupVersion), build)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
-		1: {"LANG", "en_US.utf8"},
+		1: {"LANG", "C.utf8"},
 	}
 	standardEnv := []string{
 		"SOURCE_REPOSITORY",

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -43,7 +43,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 
 	containerEnv := []v1.EnvVar{
 		{Name: "BUILD", Value: string(data)},
-		{Name: "LANG", Value: "en_US.utf8"},
+		{Name: "LANG", Value: "C.utf8"},
 	}
 
 	addSourceEnvVars(build.Spec.Source, &containerEnv)

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -141,7 +141,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	buildJSON, _ := runtime.Encode(buildJSONCodec, build)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
-		1: {"LANG", "en_US.utf8"},
+		1: {"LANG", "C.utf8"},
 	}
 	for index, exp := range errorCases {
 		if e := container.Env[index]; e.Name != exp[0] || e.Value != exp[1] {

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -40,7 +40,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 
 	containerEnv := []corev1.EnvVar{
 		{Name: "BUILD", Value: string(data)},
-		{Name: "LANG", Value: "en_US.utf8"},
+		{Name: "LANG", Value: "C.utf8"},
 	}
 
 	addSourceEnvVars(build.Spec.Source, &containerEnv)

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -200,7 +200,7 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	buildJSON, _ := runtime.Encode(buildJSONCodec, build)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
-		1: {"LANG", "en_US.utf8"},
+		1: {"LANG", "C.utf8"},
 	}
 	for index, exp := range errorCases {
 		if e := container.Env[index]; e.Name != exp[0] || e.Value != exp[1] {


### PR DESCRIPTION
Image on which `builder` is based, has been stripped from a lot of unnecessary files, including some locale files. Because of this, locale `en_US.utf8` does not exist in the builder image, which leads to `bsdtar` not working correctly with non-ansi files in the archive.
`C.utf8` does the job, though, and allows correct work with all the files.

Another possible solution would be installing `glibc-langpack-en` package in the `builder` image, but it would make the image bigger, and it doesn't seem like we really need `en_US` locale.