### PR TITLE
Bug 1954715: Increase number of image-import controller workers

### DIFF
--- a/pkg/cmd/controller/image.go
+++ b/pkg/cmd/controller/image.go
@@ -166,7 +166,7 @@ func RunImageImportController(ctx *ControllerContext) (bool, error) {
 		ctx.ClientBuilder.OpenshiftImageClientOrDie(infraImageImportControllerServiceAccountName),
 		informer,
 	)
-	go controller.Run(5, ctx.Stop)
+	go controller.Run(50, ctx.Stop)
 
 	// TODO control this using enabled and disabled controllers
 	if ctx.OpenshiftControllerConfig.ImageImport.DisableScheduledImport {

--- a/pkg/image/controller/factory.go
+++ b/pkg/image/controller/factory.go
@@ -63,7 +63,7 @@ func (opts ScheduledImageStreamControllerOptions) GetRateLimiter() flowcontrol.R
 // NewImageStreamController returns a new image stream import controller.
 func NewImageStreamController(client imagev1client.Interface, informer imagev1informer.ImageStreamInformer) *ImageStreamController {
 	controller := &ImageStreamController{
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ImageStreamController"),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "ImageStreamController"),
 
 		client:       client.ImageV1(),
 		lister:       informer.Lister(),


### PR DESCRIPTION
When the controller imports an image from a slow registry, it waits for
a response from the registry and almost doesn't consume resources. As
today we have only 5 workers, 5 requests to import from a slow registry
will block the entire queue from beging processed.