### PR TITLE
Updated Dockerfile's registry url and go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:golang-1.15 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/openshift-controller-manager/openshift-controller-manager /usr/bin/
 LABEL io.k8s.display-name="OpenShift Controller Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \


### PR DESCRIPTION
I have not been able to build this project using the default `Dockerfile` so I am proposing these changes:

- Use images from `registry.ci.openshift.org`
- Updates to use go 1.15 as used in `Dockerfile.rhel`

Please evaluate.