### PR TITLE
Bug 2004203: BC ICT still must check spec last triggered image ID in case BC was last processed when cluster was pre 4.8

### DIFF
--- a/pkg/image/trigger/buildconfigs/buildconfigs.go
+++ b/pkg/image/trigger/buildconfigs/buildconfigs.go
@@ -184,6 +184,12 @@ func (r *buildConfigReactor) ImageChanged(obj runtime.Object, tagRetriever trigg
 			// LastTriggeredImageID is an image ref, despite the name
 			continue
 		}
+		// We still need to check the old spec field as well, in case the build config in question was last
+		// triggered while the cluster was at a level prior to 4.8.
+		// LastTriggeredImageID is an image ref, despite the name
+		if latest == p.LastTriggeredImageID {
+			continue
+		}
 
 		// prevent duplicate build trigger causes
 		if fired == nil {


### PR DESCRIPTION
/assign @adambkaplan 
/assign @alicerum 