### PR TITLE
Add metric to count event with reason needPods

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -30,3 +30,8 @@ OCM exposes the following metrics to Prometheus for monitoring and analysis:
 | ---- | ---- | ------ | ----------- |
 | `openshift_template_instance_completed_total` | Counter | `condition` | Counts completed TemplateInstance objects by condition |
 | `openshift_template_instance_active_age_seconds` | Histogram | No labels | Shows the instantaneous age distribution of active TemplateInstance objects |
+
+## Unidling
+| Name | Type | Labels | Description |
+| ---- | ---- | ------ | ----------- |
+| `openshift_unidle_events_total` | Counter | No labels | Total count of unidling events observed by the unidling controller |

--- a/pkg/unidling/metrics/doc.go
+++ b/pkg/unidling/metrics/doc.go
@@ -1,0 +1,2 @@
+// Package metrics contains code for unidling controller metrics
+package metrics

--- a/pkg/unidling/metrics/metrics.go
+++ b/pkg/unidling/metrics/metrics.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	unidleCount = metrics.NewCounter(&metrics.CounterOpts{
+		Namespace: "openshift",
+		Subsystem: "unidle",
+		Name:      "events_total",
+		Help:      "Total count of unidling events observed by the unidling controller",
+	})
+	registerOnce sync.Once
+)
+
+func GetEventsTotalCounter() *metrics.Counter {
+	registerOnce.Do(func() {
+		legacyregistry.MustRegister(unidleCount)
+	})
+	return unidleCount
+}


### PR DESCRIPTION
This metric will count the number of times this
event is seen and give an indication whether
idling is used.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>