### PR TITLE
Bug 1996140: Use the new events API for unidling

### DIFF
--- a/pkg/cmd/controller/unidling.go
+++ b/pkg/cmd/controller/unidling.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/dynamic"
+	eventsv1client "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/scale"
 
 	appsclient "github.com/openshift/client-go/apps/clientset/versioned"
@@ -27,6 +28,10 @@ func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	eventClient, err := eventsv1client.NewForConfig(clientConfig)
+	if err != nil {
+		return false, err
+	}
 
 	coreClient := ctx.ClientBuilder.ClientOrDie(infraUnidlingControllerServiceAccountName).CoreV1()
 	controller := unidlingcontroller.NewUnidlingController(
@@ -34,7 +39,7 @@ func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 		ctx.RestMapper,
 		coreClient,
 		coreClient,
-		coreClient,
+		eventClient,
 		appsClient.AppsV1(),
 		coreClient,
 		resyncPeriod,


### PR DESCRIPTION
The follow changes have occurred to update
to the new events API [1] from core Events API [2]:

* LastTimestamp field is depreciated. We are
now using the Series LastObservedTime field
to detect when was the last time this event fired.
The Series pointer will be nil if
the event only occurred once.

* InvolvedObject field is placed by Regarding
field to describe namespace / name.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

~~I needed to edit cluster role `system:openshift:controller:unidling-controller` to allow this controller to listen to API `events.k8s.io`. If anyone can point me to where that clusterrole is defined, I would appreciate it.~~
See PR: https://github.com/openshift/openshift-apiserver/pull/256

~~I will put this WIP until I have tested it sufficiently with an updated SDN + OVN-K network plugins.~~

[1] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#event-v1-events-k8s-io
[2] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#event-v1-core