### PR TITLE
Bug 2034648: Use --v Option to Set Log Verbosity for Builds

### DIFF
--- a/pkg/build/controller/build/defaults/defaults.go
+++ b/pkg/build/controller/build/defaults/defaults.go
@@ -55,14 +55,14 @@ func (b BuildDefaults) ApplyDefaults(pod *corev1.Pod) error {
 func setPodLogLevelFromBuild(pod *corev1.Pod, build *buildv1.Build) error {
 	var envs []corev1.EnvVar
 
-	// Check whether the build strategy supports --loglevel parameter.
+	// Check whether the build strategy supports -v logging parameter.
 	switch {
 	case build.Spec.Strategy.DockerStrategy != nil:
 		envs = build.Spec.Strategy.DockerStrategy.Env
 	case build.Spec.Strategy.SourceStrategy != nil:
 		envs = build.Spec.Strategy.SourceStrategy.Env
 	default:
-		// The build strategy does not support --loglevel
+		// The build strategy does not support -v logging directly.
 		return nil
 	}
 
@@ -75,9 +75,9 @@ func setPodLogLevelFromBuild(pod *corev1.Pod, build *buildv1.Build) error {
 		}
 	}
 	c := &pod.Spec.Containers[0]
-	c.Args = append(c.Args, "--loglevel="+buildLogLevel)
+	c.Args = append(c.Args, "--v="+buildLogLevel)
 	for i := range pod.Spec.InitContainers {
-		pod.Spec.InitContainers[i].Args = append(pod.Spec.InitContainers[i].Args, "--loglevel="+buildLogLevel)
+		pod.Spec.InitContainers[i].Args = append(pod.Spec.InitContainers[i].Args, "--v="+buildLogLevel)
 	}
 	return nil
 }

--- a/pkg/build/controller/build/defaults/defaults_test.go
+++ b/pkg/build/controller/build/defaults/defaults_test.go
@@ -835,8 +835,14 @@ func TestSetBuildLogLevel(t *testing.T) {
 		t.Errorf("Builds pod loglevel was not set")
 	}
 
-	if pod.Spec.Containers[0].Args[0] != "--loglevel=0" {
+	if pod.Spec.Containers[0].Args[0] != "--v=0" {
 		t.Errorf("Default build pod loglevel was not set to 0")
+	}
+
+	for _, initContainer := range pod.Spec.InitContainers {
+		if initContainer.Args[0] != "--v=0" {
+			t.Errorf("Default build pod log level for init container %s was not set to 0", initContainer.Name)
+		}
 	}
 
 	build = testutil.Build().WithSourceStrategy()
@@ -844,8 +850,14 @@ func TestSetBuildLogLevel(t *testing.T) {
 	build.Spec.Strategy.SourceStrategy.Env = []corev1.EnvVar{{Name: "BUILD_LOGLEVEL", Value: "7", ValueFrom: nil}}
 	setPodLogLevelFromBuild((*corev1.Pod)(pod), build.AsBuild())
 
-	if pod.Spec.Containers[0].Args[0] != "--loglevel=7" {
+	if pod.Spec.Containers[0].Args[0] != "--v=7" {
 		t.Errorf("Build pod loglevel was not transferred from BUILD_LOGLEVEL environment variable: %#v", pod)
+	}
+
+	for _, initContainer := range pod.Spec.InitContainers {
+		if initContainer.Args[0] != "--v=7" {
+			t.Errorf("Build pod loglevel was not transferred to init container %s from BUILD_LOGLEVEL environment variable: %#v", initContainer.Name, pod)
+		}
 	}
 
 }

--- a/pkg/build/controller/common/testutil/pod.go
+++ b/pkg/build/controller/common/testutil/pod.go
@@ -33,10 +33,10 @@ func (p *TestPod) WithTolerations(tolerations []corev1.Toleration) *TestPod {
 
 func (p *TestPod) WithEnvVar(name, value string) *TestPod {
 	if len(p.Spec.InitContainers) == 0 {
-		p.Spec.InitContainers = append(p.Spec.InitContainers, corev1.Container{})
+		p.Spec.InitContainers = append(p.Spec.InitContainers, corev1.Container{Name: "git-init"})
 	}
 	if len(p.Spec.Containers) == 0 {
-		p.Spec.Containers = append(p.Spec.Containers, corev1.Container{})
+		p.Spec.Containers = append(p.Spec.Containers, corev1.Container{Name: "image-build"})
 	}
 	p.Spec.InitContainers[0].Env = append(p.Spec.InitContainers[0].Env, corev1.EnvVar{Name: name, Value: value})
 	p.Spec.Containers[0].Env = append(p.Spec.Containers[0].Env, corev1.EnvVar{Name: name, Value: value})


### PR DESCRIPTION
Use standard klog --v option to set log verbosity on Source and Docker
strategy builds, instead of our custom `--loglevel` option. The rebase
to k8s 1.23 prevents us from injecting the `--loglevel` option.