### PR TITLE
Accept stop signal

### DIFF
--- a/cmd/openshift-controller-manager/main.go
+++ b/cmd/openshift-controller-manager/main.go
@@ -62,7 +62,7 @@ func NewOpenShiftControllerManagerCommand(stopCh <-chan struct{}) *cobra.Command
 			os.Exit(1)
 		},
 	}
-	start := openshift_controller_manager.NewOpenShiftControllerManagerCommand("start", os.Stdout, os.Stderr)
+	start := openshift_controller_manager.NewOpenShiftControllerManagerCommand("start", os.Stdout, os.Stderr, stopCh)
 	cmd.AddCommand(start)
 
 	return cmd

--- a/pkg/cmd/openshift-controller-manager/cmd.go
+++ b/pkg/cmd/openshift-controller-manager/cmd.go
@@ -34,7 +34,7 @@ type OpenShiftControllerManager struct {
 var longDescription = templates.LongDesc(`
 	Start the OpenShift controllers`)
 
-func NewOpenShiftControllerManagerCommand(name string, out, errout io.Writer) *cobra.Command {
+func NewOpenShiftControllerManagerCommand(name string, out, errout io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	options := &OpenShiftControllerManager{Output: out}
 
 	cmd := &cobra.Command{
@@ -46,7 +46,7 @@ func NewOpenShiftControllerManagerCommand(name string, out, errout io.Writer) *c
 
 			serviceability.StartProfiler()
 
-			if err := options.StartControllerManager(); err != nil {
+			if err := options.StartControllerManager(stopCh); err != nil {
 				if kerrors.IsInvalid(err) {
 					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
 						fmt.Fprintf(errout, "Invalid %s %s\n", details.Kind, details.Name)
@@ -79,13 +79,18 @@ func (o *OpenShiftControllerManager) Validate() error {
 }
 
 // StartControllerManager calls RunControllerManager and then waits forever
-func (o *OpenShiftControllerManager) StartControllerManager() error {
+func (o *OpenShiftControllerManager) StartControllerManager(stopCh <-chan struct{}) error {
 	if err := o.RunControllerManager(); err != nil {
 		return err
 	}
 
 	go daemon.SdNotify(false, "READY=1")
-	select {}
+
+	select {
+	case <-stopCh:
+		klog.Infof("Controller Manager received stop signal. exiting.")
+		return nil
+	}
 }
 
 // RunControllerManager takes the options and starts the controllers


### PR DESCRIPTION
One problem this fixes is during a node reboot when a SIGTERM
is given to the container it will stop in a timely fashion.
without this, the node has to wait for it's timeout (e.g., 30s)
before giving up and SIGKILL'ing it.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>