### PR TITLE
NE-860: ingress-to-route: add support for destinationCACertificate

### DIFF
--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -635,10 +635,12 @@ func preserveRouteAttributesFromExisting(r, existing *routev1.Route) {
 	r.Spec.To.Weight = existing.Spec.To.Weight
 	if r.Spec.TLS != nil && existing.Spec.TLS != nil {
 		r.Spec.TLS.CACertificate = existing.Spec.TLS.CACertificate
-		if _, ok := r.Annotations[destinationCACertificateAnnotationKey]; !ok {
-			r.Spec.TLS.DestinationCACertificate = existing.Spec.TLS.DestinationCACertificate
-		}
 		r.Spec.TLS.InsecureEdgeTerminationPolicy = existing.Spec.TLS.InsecureEdgeTerminationPolicy
+		if r.Spec.TLS.Termination == routev1.TLSTerminationReencrypt {
+			if _, ok := r.Annotations[destinationCACertificateAnnotationKey]; !ok {
+				r.Spec.TLS.DestinationCACertificate = existing.Spec.TLS.DestinationCACertificate
+			}
+		}
 	}
 }
 

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -900,7 +900,6 @@ func terminationPolicyForIngress(ingress *networkingv1.Ingress) routev1.TLSTermi
 	}
 }
 
-var destinationCACertificateSecretKeyName = "destinationCACertificate"
 var destinationCACertificateAnnotationKey = routev1.GroupName + "/destination-ca-certificate-secret"
 
 func destinationCACertificateForIngress(ingress *networkingv1.Ingress, secretLister corelisters.SecretLister) *string {

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -899,10 +899,12 @@ func destinationCACertificateForIngress(ingress *networkingv1.Ingress, secretLis
 	if err != nil {
 		return nil
 	}
-	if secret.Type != corev1.SecretTypeOpaque {
+	switch secret.Type {
+	case corev1.SecretTypeTLS, corev1.SecretTypeOpaque:
+	default:
 		return nil
 	}
-	if v, ok := secret.Data[destinationCACertificateSecretKeyName]; ok {
+	if v, ok := secret.Data[corev1.TLSCertKey]; ok {
 		value := string(v)
 		return &value
 	}

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -891,7 +891,7 @@ func terminationPolicyForIngress(ingress *networkingv1.Ingress) routev1.TLSTermi
 }
 
 var destinationCACertificateSecretKeyName = "destinationCACertificate"
-var destinationCACertificateAnnotationKey = routev1.GroupName + "/destinationCACertificateSecret"
+var destinationCACertificateAnnotationKey = routev1.GroupName + "/destination-ca-certificate-secret"
 
 func destinationCACertificateForIngress(ingress *networkingv1.Ingress, secretLister corelisters.SecretLister) *string {
 	name := ingress.Annotations[destinationCACertificateAnnotationKey]

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -635,7 +635,6 @@ func preserveRouteAttributesFromExisting(r, existing *routev1.Route) {
 	r.Spec.To.Weight = existing.Spec.To.Weight
 	if r.Spec.TLS != nil && existing.Spec.TLS != nil {
 		r.Spec.TLS.CACertificate = existing.Spec.TLS.CACertificate
-		r.Spec.TLS.DestinationCACertificate = existing.Spec.TLS.DestinationCACertificate
 		r.Spec.TLS.InsecureEdgeTerminationPolicy = existing.Spec.TLS.InsecureEdgeTerminationPolicy
 	}
 }

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -635,6 +635,9 @@ func preserveRouteAttributesFromExisting(r, existing *routev1.Route) {
 	r.Spec.To.Weight = existing.Spec.To.Weight
 	if r.Spec.TLS != nil && existing.Spec.TLS != nil {
 		r.Spec.TLS.CACertificate = existing.Spec.TLS.CACertificate
+		if _, ok := r.Annotations[destinationCACertificateAnnotationKey]; !ok {
+			r.Spec.TLS.DestinationCACertificate = existing.Spec.TLS.DestinationCACertificate
+		}
 		r.Spec.TLS.InsecureEdgeTerminationPolicy = existing.Spec.TLS.InsecureEdgeTerminationPolicy
 	}
 }
@@ -686,6 +689,9 @@ func routeMatchesIngress(
 	tlsConfig := tlsConfigForIngress(ingress, rule, tlsSecret, secretLister)
 	if route.Spec.TLS != nil && tlsConfig != nil {
 		tlsConfig.InsecureEdgeTerminationPolicy = route.Spec.TLS.InsecureEdgeTerminationPolicy
+		if _, ok := ingress.Annotations[destinationCACertificateAnnotationKey]; !ok {
+			tlsConfig.DestinationCACertificate = route.Spec.TLS.DestinationCACertificate
+		}
 	}
 	return reflect.DeepEqual(tlsConfig, route.Spec.TLS)
 }

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -878,7 +878,6 @@ func tlsSecretIfValid(ingress *networkingv1.Ingress, rule *networkingv1.IngressR
 }
 
 var terminationPolicyAnnotationKey = routev1.GroupName + "/termination"
-var destinationCACertificateAnnotationKey = routev1.GroupName + "/destinationCACertificate"
 
 func terminationPolicyForIngress(ingress *networkingv1.Ingress) routev1.TLSTerminationType {
 	switch {
@@ -890,9 +889,12 @@ func terminationPolicyForIngress(ingress *networkingv1.Ingress) routev1.TLSTermi
 		return routev1.TLSTerminationEdge
 	}
 }
+
+var destinationCACertificateSecretKeyName = "destinationCACertificate"
+var destinationCACertificateAnnotationKey = routev1.GroupName + "/destinationCACertificateSecret"
+
 func destinationCACertificateForIngress(ingress *networkingv1.Ingress, secretLister corelisters.SecretLister) *string {
 	name := ingress.Annotations[destinationCACertificateAnnotationKey]
-	secretDataKey := "destinationCACertificate"
 	secret, err := secretLister.Secrets(ingress.Namespace).Get(name)
 	if err != nil {
 		return nil
@@ -900,7 +902,7 @@ func destinationCACertificateForIngress(ingress *networkingv1.Ingress, secretLis
 	if secret.Type != corev1.SecretTypeOpaque {
 		return nil
 	}
-	if v, ok := secret.Data[secretDataKey]; ok {
+	if v, ok := secret.Data[destinationCACertificateSecretKeyName]; ok {
 		value := string(v)
 		return &value
 	}

--- a/pkg/route/ingress/ingress.go
+++ b/pkg/route/ingress/ingress.go
@@ -201,7 +201,7 @@ func NewController(eventsClient kv1core.EventsGetter, routeClient routeclient.Ro
 		FilterFunc: func(obj interface{}) bool {
 			switch t := obj.(type) {
 			case *corev1.Secret:
-				return t.Type == corev1.SecretTypeTLS
+				return t.Type == corev1.SecretTypeTLS || t.Type == corev1.SecretTypeOpaque
 			}
 			return true
 		},

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -898,7 +899,6 @@ func TestController_sync(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "create route - with termination reencypt and destinationCaCert",
 			fields: fields{
@@ -908,8 +908,8 @@ func TestController_sync(t *testing.T) {
 							Name:      "1",
 							Namespace: "test",
 							Annotations: map[string]string{
-								"route.openshift.io/termination":                    "reencrypt",
-								"route.openshift.io/destinationCACertificateSecret": "secret-ca-cert",
+								"route.openshift.io/termination":                       "reencrypt",
+								"route.openshift.io/destination-ca-certificate-secret": "secret-ca-cert",
 							},
 						},
 						Spec: networkingv1.IngressSpec{
@@ -953,8 +953,8 @@ func TestController_sync(t *testing.T) {
 						Namespace:       "test",
 						OwnerReferences: []metav1.OwnerReference{{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
 						Annotations: map[string]string{
-							"route.openshift.io/termination":                    "reencrypt",
-							"route.openshift.io/destinationCACertificateSecret": "secret-ca-cert",
+							"route.openshift.io/termination":                       "reencrypt",
+							"route.openshift.io/destination-ca-certificate-secret": "secret-ca-cert",
 						},
 					},
 					Spec: routev1.RouteSpec{
@@ -2118,8 +2118,8 @@ func TestController_sync(t *testing.T) {
 							Name:      "1",
 							Namespace: "test",
 							Annotations: map[string]string{
-								"route.openshift.io/termination":                    "reencrypt",
-								"route.openshift.io/destinationCACertificateSecret": "secret-ca-cert",
+								"route.openshift.io/termination":                       "reencrypt",
+								"route.openshift.io/destination-ca-certificate-secret": "secret-ca-cert",
 							},
 						},
 						Spec: networkingv1.IngressSpec{
@@ -2179,8 +2179,17 @@ func TestController_sync(t *testing.T) {
 			args: queueKey{namespace: "test", name: "1"},
 			wantRoutePatches: []clientgotesting.PatchActionImpl{
 				{
-					Name:  "1-abcdef",
-					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"},"tls":{"termination":"reencrypt","destinationCACertificate":"CAcert","insecureEdgeTerminationPolicy":"Redirect"}}},{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/destinationCACertificateSecret":"secret-ca-cert","route.openshift.io/termination":"reencrypt"}},{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`),
+					Name: "1-abcdef",
+					Patch: []byte(
+						strings.Join(
+							[]string{
+								`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"},"tls":{"termination":"reencrypt","destinationCACertificate":"CAcert","insecureEdgeTerminationPolicy":"Redirect"}}}`,
+								`{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/destination-ca-certificate-secret":"secret-ca-cert","route.openshift.io/termination":"reencrypt"}}`,
+								`{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`,
+							},
+							",",
+						),
+					),
 				},
 			},
 		},

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -1685,6 +1685,73 @@ func TestController_sync(t *testing.T) {
 			},
 		},
 		{
+			name: "update ingress with missing secret ref",
+			fields: fields{
+				i: &ingressLister{Items: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+						},
+						Spec: networkingv1.IngressSpec{
+							TLS: []networkingv1.IngressTLS{
+								{Hosts: []string{"test.com"}, SecretName: "secret-4"},
+							},
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &pathTypePrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-1",
+															Port: networkingv1.ServiceBackendPort{
+																Name: "http",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				r: &routeLister{Items: []*routev1.Route{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "1-abcdef",
+							Namespace:       "test",
+							OwnerReferences: []metav1.OwnerReference{{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
+						},
+						Spec: routev1.RouteSpec{
+							Host: "test.com",
+							Path: "/",
+							To: routev1.RouteTargetReference{
+								Name: "service-1",
+							},
+							Port: &routev1.RoutePort{
+								TargetPort: intstr.FromString("http"),
+							},
+							WildcardPolicy: routev1.WildcardPolicyNone,
+						},
+					},
+				}},
+			},
+			args: queueKey{namespace: "test", name: "1"},
+			wantRouteDeletes: []clientgotesting.DeleteActionImpl{
+				{
+					Name: "1-abcdef",
+				},
+			},
+		},
+		{
 			name: "update ingress to not reference secret",
 			fields: fields{
 				i: &ingressLister{Items: []*networkingv1.Ingress{
@@ -2195,6 +2262,94 @@ func TestController_sync(t *testing.T) {
 							[]string{
 								`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"},"tls":{"termination":"reencrypt","destinationCACertificate":"CAcert","insecureEdgeTerminationPolicy":"Redirect"}}}`,
 								`{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/destination-ca-certificate-secret":"secret-ca-cert","route.openshift.io/termination":"reencrypt"}}`,
+								`{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`,
+							},
+							",",
+						),
+					),
+				},
+			},
+		},
+		{
+			name: "update route - termination policy changed from reencrypt to to edge - Must clear destinationCaCertificate",
+			fields: fields{
+				i: &ingressLister{Items: []*networkingv1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+							Annotations: map[string]string{
+								"route.openshift.io/termination": "edge",
+							},
+						},
+						Spec: networkingv1.IngressSpec{
+							Rules: []networkingv1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: networkingv1.IngressRuleValue{
+										HTTP: &networkingv1.HTTPIngressRuleValue{
+											Paths: []networkingv1.HTTPIngressPath{
+												{
+													Path:     "/",
+													PathType: &pathTypePrefix,
+													Backend: networkingv1.IngressBackend{
+														Service: &networkingv1.IngressServiceBackend{
+															Name: "service-1",
+															Port: networkingv1.ServiceBackendPort{
+																Name: "http",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				r: &routeLister{Items: []*routev1.Route{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1-abcdef",
+							Namespace: "test",
+							Annotations: map[string]string{
+								"route.openshift.io/termination":                       "reencrypt",
+								"route.openshift.io/destination-ca-certificate-secret": "secret-ca-cert",
+							},
+							OwnerReferences: []metav1.OwnerReference{{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
+						},
+						Spec: routev1.RouteSpec{
+							Host: "test.com",
+							Path: "/",
+							TLS: &routev1.TLSConfig{
+								Termination:                   routev1.TLSTerminationReencrypt,
+								Certificate:                   "cert",
+								Key:                           "key",
+								InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+								DestinationCACertificate:      "CACert",
+							},
+							To: routev1.RouteTargetReference{
+								Name: "service-1",
+							},
+							Port: &routev1.RoutePort{
+								TargetPort: intstr.FromString("http"),
+							},
+							WildcardPolicy: routev1.WildcardPolicyNone,
+						},
+					},
+				}},
+			},
+			args: queueKey{namespace: "test", name: "1"},
+			wantRoutePatches: []clientgotesting.PatchActionImpl{
+				{
+					Name: "1-abcdef",
+					Patch: []byte(
+						strings.Join(
+							[]string{
+								`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"},"tls":{"termination":"edge","insecureEdgeTerminationPolicy":"Redirect"}}}`,
+								`{"op":"replace","path":"/metadata/annotations","value":{"route.openshift.io/termination":"edge"}}`,
 								`{"op":"replace","path":"/metadata/ownerReferences","value":[{"apiVersion":"networking.k8s.io/v1","kind":"Ingress","name":"1","uid":"","controller":true}]}]`,
 							},
 							",",

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -3559,7 +3559,7 @@ func TestController_sync(t *testing.T) {
 					t.Errorf("unexpected action[%d]: %#v", i, action)
 				}
 				if !reflect.DeepEqual(string(action.GetPatch()), string(tt.wantRoutePatches[i].Patch)) {
-					t.Errorf("unexpected action[%d]: %s -- %s", i, string(action.GetPatch()), string(tt.wantRoutePatches[i].Patch))
+					t.Errorf("unexpected action[%d]: %s", i, string(action.GetPatch()))
 				}
 			}
 			routeActions = routeActions[len(tt.wantRoutePatches):]

--- a/pkg/route/ingress/ingress_test.go
+++ b/pkg/route/ingress/ingress_test.go
@@ -503,7 +503,7 @@ func TestController_sync(t *testing.T) {
 			},
 			Type: v1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				"destinationCACertificate": []byte(`CAcert`),
+				v1.TLSCertKey: []byte(`CAcert`),
 			},
 		},
 	}}


### PR DESCRIPTION
## Overview

This PR is the continuation of #153. It adds the requests made on the original PR.

* The annotation now is a reference to a secret. The secret contains the CA to validate the backend certificate
* Added tests for this feature. 
* I've considered to change the annotation name to include "Secret" at the end. 

## Example 

```yaml
kind: Ingress
apiVersion: networking.k8s.io/v1beta1
metadata:
  annotations:
    route.openshift.io/destination-ca-certificate-secret: <existing-secret-in-the-same-namespace>
    route.openshift.io/termination: reencrypt
...
```

will generate: 

```yaml
kind: Route
metadata:
  annotations:
    route.openshift.io/termination: reencrypt
    route.openshift.io/destination-ca-certificate-secret: <existing-secret-in-the-same-namespace>
spec:
 ...
  tls:
    termination: reencrypt
    destinationCACertificate: |
        `tls.crt key secret contents`
   ...
```
 
let me know if something else is needed.
