### PR TITLE
Bug 2075584: Bubble actual error message up to the build

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1231,7 +1231,7 @@ func (bc *BuildController) createBuildPod(build *buildv1.Build) (*buildUpdate, e
 				"Unable to resolve build environment variable reference.", err.Error()))
 		default:
 			update.setReason(buildv1.StatusReasonCannotCreateBuildPodSpec)
-			update.setMessage("Failed to create pod spec.")
+			update.setMessage(fmt.Sprintf("Failed to create pod spec: %s", err.Error()))
 
 		}
 		// If an error occurred when creating the pod spec, it likely means
@@ -1258,7 +1258,7 @@ func (bc *BuildController) createBuildPod(build *buildv1.Build) (*buildUpdate, e
 		// Log an event if the pod is not created (most likely due to quota denial).
 		bc.recorder.Eventf(build, corev1.EventTypeWarning, "FailedCreate", "Error creating build pod: %v", err)
 		update.setReason(buildv1.StatusReasonCannotCreateBuildPod)
-		update.setMessage("Failed creating build pod.")
+		update.setMessage(fmt.Sprintf("Failed creating build pod: %s", err.Error()))
 		return update, fmt.Errorf("failed to create build pod: %v", err)
 
 	} else if err != nil {

--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -700,7 +700,7 @@ func TestCreateBuildPodWithPodSpecCreationError(t *testing.T) {
 	}
 	expected := &buildUpdate{}
 	expected.setReason(buildv1.StatusReasonCannotCreateBuildPodSpec)
-	expected.setMessage("Failed to create pod spec.")
+	expected.setMessage("Failed to create pod spec: failed to create a build pod spec for build namespace/data-build: error")
 	validateUpdate(t, "create build pod with pod spec creation error", expected, update)
 }
 
@@ -1023,7 +1023,7 @@ func TestCreateBuildPodWithPodCreationError(t *testing.T) {
 
 	expected := &buildUpdate{}
 	expected.setReason(buildv1.StatusReasonCannotCreateBuildPod)
-	expected.setMessage("Failed creating build pod.")
+	expected.setMessage("Failed creating build pod: error")
 	validateUpdate(t, "create build pod with pod creation error", expected, update)
 }
 


### PR DESCRIPTION
Include the error string in the message that is set on the build
so that it is easily seen by the user, instead of them having to
dig through the OCM controller logs to find it.