### PR TITLE
WIP: allow for future extraction of route controllers

### DIFF
--- a/pkg/route/allocator/bitmap.go
+++ b/pkg/route/allocator/bitmap.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"errors"
+	"math/big"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// AllocationBitmap is a contiguous block of resources that can be allocated atomically.
+//
+// Each resource has an offset.  The internal structure is a bitmap, with a bit for each offset.
+//
+// If a resource is taken, the bit at that offset is set to one.
+// r.count is always equal to the number of set bits and can be recalculated at any time
+// by counting the set bits in r.allocated.
+//
+// TODO: use RLE and compact the allocator to minimize space.
+type AllocationBitmap struct {
+	// strategy carries the details of how to choose the next available item out of the range
+	strategy bitAllocator
+	// max is the maximum size of the usable items in the range
+	max int
+	// rangeSpec is the range specifier, matching RangeAllocation.Range
+	rangeSpec string
+
+	// lock guards the following members
+	lock sync.Mutex
+	// count is the number of currently allocated elements in the range
+	count int
+	// allocated is a bit array of the allocated items in the range
+	allocated *big.Int
+}
+
+// AllocationBitmap implements Interface and Snapshottable
+var _ Interface = &AllocationBitmap{}
+var _ Snapshottable = &AllocationBitmap{}
+
+// bitAllocator represents a search strategy in the allocation map for a valid item.
+type bitAllocator interface {
+	AllocateBit(allocated *big.Int, max, count int) (int, bool)
+}
+
+// NewAllocationMap creates an allocation bitmap using the random scan strategy.
+func NewAllocationMap(max int, rangeSpec string) *AllocationBitmap {
+	a := AllocationBitmap{
+		strategy: randomScanStrategy{
+			rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+		},
+		allocated: big.NewInt(0),
+		count:     0,
+		max:       max,
+		rangeSpec: rangeSpec,
+	}
+	return &a
+}
+
+// Allocate attempts to reserve the provided item.
+// Returns true if it was allocated, false if it was already in use
+func (r *AllocationBitmap) Allocate(offset int) (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 1 {
+		return false, nil
+	}
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 1)
+	r.count++
+	return true, nil
+}
+
+// AllocateNext reserves one of the items from the pool.
+// (0, false, nil) may be returned if there are no items left.
+func (r *AllocationBitmap) AllocateNext() (int, bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	next, ok := r.strategy.AllocateBit(r.allocated, r.max, r.count)
+	if !ok {
+		return 0, false, nil
+	}
+	r.count++
+	r.allocated = r.allocated.SetBit(r.allocated, next, 1)
+	return next, true, nil
+}
+
+// Release releases the item back to the pool. Releasing an
+// unallocated item or an item out of the range is a no-op and
+// returns no error.
+func (r *AllocationBitmap) Release(offset int) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 0 {
+		return nil
+	}
+
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 0)
+	r.count--
+	return nil
+}
+
+const (
+	// Find the size of a big.Word in bytes.
+	notZero   = uint64(^big.Word(0))
+	wordPower = (notZero>>8)&1 + (notZero>>16)&1 + (notZero>>32)&1
+	wordSize  = 1 << wordPower
+)
+
+// ForEach calls the provided function for each allocated bit.  The
+// AllocationBitmap may not be modified while this loop is running.
+func (r *AllocationBitmap) ForEach(fn func(int)) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	words := r.allocated.Bits()
+	for wordIdx, word := range words {
+		bit := 0
+		for word > 0 {
+			if (word & 1) != 0 {
+				fn((wordIdx * wordSize * 8) + bit)
+				word = word &^ 1
+			}
+			bit++
+			word = word >> 1
+		}
+	}
+}
+
+// Has returns true if the provided item is already allocated and a call
+// to Allocate(offset) would fail.
+func (r *AllocationBitmap) Has(offset int) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.allocated.Bit(offset) == 1
+}
+
+// Free returns the count of items left in the range.
+func (r *AllocationBitmap) Free() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.max - r.count
+}
+
+// Snapshot saves the current state of the pool.
+func (r *AllocationBitmap) Snapshot() (string, []byte) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.rangeSpec, r.allocated.Bytes()
+}
+
+// Restore restores the pool to the previously captured state.
+func (r *AllocationBitmap) Restore(rangeSpec string, data []byte) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.rangeSpec != rangeSpec {
+		return errors.New("the provided range does not match the current range")
+	}
+
+	r.allocated = big.NewInt(0).SetBytes(data)
+	r.count = countBits(r.allocated)
+
+	return nil
+}
+
+// randomScanStrategy chooses a random address from the provided big.Int, and then
+// scans forward looking for the next available address (it will wrap the range if
+// necessary).
+type randomScanStrategy struct {
+	rand *rand.Rand
+}
+
+func (rss randomScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
+	if count >= max {
+		return 0, false
+	}
+	offset := rss.rand.Intn(max)
+	for i := 0; i < max; i++ {
+		at := (offset + i) % max
+		if allocated.Bit(at) == 0 {
+			return at, true
+		}
+	}
+	return 0, false
+}
+
+var _ bitAllocator = randomScanStrategy{}

--- a/pkg/route/allocator/interfaces.go
+++ b/pkg/route/allocator/interfaces.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+// Interface manages the allocation of items out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(int) (bool, error)
+	AllocateNext() (int, bool, error)
+	Release(int) error
+	ForEach(func(int))
+
+	// For testing
+	Has(int) bool
+
+	// For testing
+	Free() int
+}
+
+// Snapshottable is an Interface that can be snapshotted and restored. Snapshottable
+// should be threadsafe.
+type Snapshottable interface {
+	Interface
+	Snapshot() (string, []byte)
+	Restore(string, []byte) error
+}
+
+type AllocatorFactory func(max int, rangeSpec string) (Interface, error)

--- a/pkg/route/allocator/utils.go
+++ b/pkg/route/allocator/utils.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"math/big"
+	"math/bits"
+)
+
+// countBits returns the number of set bits in n
+func countBits(n *big.Int) int {
+	var count int = 0
+	for _, w := range n.Bits() {
+		count += bits.OnesCount64(uint64(w))
+	}
+	return count
+}

--- a/pkg/route/ingressip/service_ingressip_controller_test.go
+++ b/pkg/route/ingressip/service_ingressip_controller_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,11 +19,15 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kubernetes/pkg/controller"
-	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
+
+	"github.com/openshift/openshift-controller-manager/pkg/route/ipallocator"
 )
 
 const namespace = "ns"
+
+func noResyncPeriodFunc() time.Duration {
+	return 0
+}
 
 func newController(t *testing.T, client *fake.Clientset, stopCh <-chan struct{}) *IngressIPController {
 	_, ipNet, err := net.ParseCIDR("172.16.0.12/28")
@@ -33,7 +37,7 @@ func newController(t *testing.T, client *fake.Clientset, stopCh <-chan struct{})
 	if client == nil {
 		client = fake.NewSimpleClientset()
 	}
-	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+	informerFactory := informers.NewSharedInformerFactory(client, noResyncPeriodFunc())
 	controller := NewIngressIPController(
 		informerFactory.Core().V1().Services().Informer(),
 		client, ipNet, 10*time.Minute,

--- a/pkg/route/ipallocator/allocator.go
+++ b/pkg/route/ipallocator/allocator.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipallocator
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+
+	api "k8s.io/kubernetes/pkg/apis/core"
+
+	"github.com/openshift/openshift-controller-manager/pkg/route/allocator"
+	corev1 "k8s.io/api/core/v1"
+	netutils "k8s.io/utils/net"
+)
+
+// Interface manages the allocation of IP addresses out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(net.IP) error
+	AllocateNext() (net.IP, error)
+	Release(net.IP) error
+	ForEach(func(net.IP))
+	CIDR() net.IPNet
+	IPFamily() corev1.IPFamily
+	Has(ip net.IP) bool
+
+	// DryRun offers a way to try operations without persisting them.
+	DryRun() Interface
+}
+
+var (
+	ErrFull              = errors.New("range is full")
+	ErrAllocated         = errors.New("provided IP is already allocated")
+	ErrMismatchedNetwork = errors.New("the provided network does not match the current range")
+)
+
+type ErrNotInRange struct {
+	IP         net.IP
+	ValidRange string
+}
+
+func (e *ErrNotInRange) Error() string {
+	return fmt.Sprintf("the provided IP (%v) is not in the valid range. The range of valid IPs is %s", e.IP, e.ValidRange)
+}
+
+// Range is a contiguous block of IPs that can be allocated atomically.
+//
+// The internal structure of the range is:
+//
+//   For CIDR 10.0.0.0/24
+//   254 addresses usable out of 256 total (minus base and broadcast IPs)
+//     The number of usable addresses is r.max
+//
+//   CIDR base IP          CIDR broadcast IP
+//   10.0.0.0                     10.0.0.255
+//   |                                     |
+//   0 1 2 3 4 5 ...         ... 253 254 255
+//     |                              |
+//   r.base                     r.base + r.max
+//     |                              |
+//   offset #0 of r.allocated   last offset of r.allocated
+type Range struct {
+	net *net.IPNet
+	// base is a cached version of the start IP in the CIDR range as a *big.Int
+	base *big.Int
+	// max is the maximum size of the usable addresses in the range
+	max int
+	// family is the IP family of this range
+	family corev1.IPFamily
+
+	alloc allocator.Interface
+}
+
+// New creates a Range over a net.IPNet, calling allocatorFactory to construct the backing store.
+func New(cidr *net.IPNet, allocatorFactory allocator.AllocatorFactory) (*Range, error) {
+	registerMetrics()
+
+	max := netutils.RangeSize(cidr)
+	base := netutils.BigForIP(cidr.IP)
+	rangeSpec := cidr.String()
+	var family corev1.IPFamily
+
+	if netutils.IsIPv6CIDR(cidr) {
+		family = corev1.IPv6Protocol
+		// Limit the max size, since the allocator keeps a bitmap of that size.
+		if max > 65536 {
+			max = 65536
+		}
+	} else {
+		family = corev1.IPv4Protocol
+		// Don't use the IPv4 network's broadcast address, but don't just
+		// Allocate() it - we don't ever want to be able to release it.
+		max--
+	}
+
+	// Don't use the network's ".0" address, but don't just Allocate() it - we
+	// don't ever want to be able to release it.
+	base.Add(base, big.NewInt(1))
+	max--
+
+	r := Range{
+		net:    cidr,
+		base:   base,
+		max:    maximum(0, int(max)),
+		family: family,
+	}
+	var err error
+	r.alloc, err = allocatorFactory(r.max, rangeSpec)
+
+	return &r, err
+}
+
+// NewInMemory creates an in-memory allocator.
+func NewInMemory(cidr *net.IPNet) (*Range, error) {
+	return New(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
+		return allocator.NewAllocationMap(max, rangeSpec), nil
+	})
+}
+
+// NewFromSnapshot allocates a Range and initializes it from a snapshot.
+func NewFromSnapshot(snap *api.RangeAllocation) (*Range, error) {
+	_, ipnet, err := netutils.ParseCIDRSloppy(snap.Range)
+	if err != nil {
+		return nil, err
+	}
+	r, err := NewInMemory(ipnet)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.Restore(ipnet, snap.Data); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func maximum(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Free returns the count of IP addresses left in the range.
+func (r *Range) Free() int {
+	return r.alloc.Free()
+}
+
+// Used returns the count of IP addresses used in the range.
+func (r *Range) Used() int {
+	return r.max - r.alloc.Free()
+}
+
+// CIDR returns the CIDR covered by the range.
+func (r *Range) CIDR() net.IPNet {
+	return *r.net
+}
+
+// DryRun returns a non-persisting form of this Range.
+func (r *Range) DryRun() Interface {
+	return dryRunRange{r}
+}
+
+// For clearer code.
+const dryRunTrue = true
+const dryRunFalse = false
+
+// Allocate attempts to reserve the provided IP. ErrNotInRange or
+// ErrAllocated will be returned if the IP is not valid for this range
+// or has already been reserved.  ErrFull will be returned if there
+// are no addresses left.
+func (r *Range) Allocate(ip net.IP) error {
+	return r.allocate(ip, dryRunFalse)
+}
+
+func (r *Range) allocate(ip net.IP, dryRun bool) error {
+	label := r.CIDR()
+	ok, offset := r.contains(ip)
+	if !ok {
+		// update metrics
+		clusterIPAllocationErrors.WithLabelValues(label.String()).Inc()
+		return &ErrNotInRange{ip, r.net.String()}
+	}
+	if dryRun {
+		// Don't bother to check whether the IP is actually free. It's racy and
+		// not worth the effort to plumb any further.
+		return nil
+	}
+
+	allocated, err := r.alloc.Allocate(offset)
+	if err != nil {
+		// update metrics
+		clusterIPAllocationErrors.WithLabelValues(label.String()).Inc()
+
+		return err
+	}
+	if !allocated {
+		// update metrics
+		clusterIPAllocationErrors.WithLabelValues(label.String()).Inc()
+
+		return ErrAllocated
+	}
+	// update metrics
+	clusterIPAllocations.WithLabelValues(label.String()).Inc()
+	clusterIPAllocated.WithLabelValues(label.String()).Set(float64(r.Used()))
+	clusterIPAvailable.WithLabelValues(label.String()).Set(float64(r.Free()))
+
+	return nil
+}
+
+// AllocateNext reserves one of the IPs from the pool. ErrFull may
+// be returned if there are no addresses left.
+func (r *Range) AllocateNext() (net.IP, error) {
+	return r.allocateNext(dryRunFalse)
+}
+
+func (r *Range) allocateNext(dryRun bool) (net.IP, error) {
+	label := r.CIDR()
+	if dryRun {
+		// Don't bother finding a free value. It's racy and not worth the
+		// effort to plumb any further.
+		return r.CIDR().IP, nil
+	}
+
+	offset, ok, err := r.alloc.AllocateNext()
+	if err != nil {
+		// update metrics
+		clusterIPAllocationErrors.WithLabelValues(label.String()).Inc()
+
+		return nil, err
+	}
+	if !ok {
+		// update metrics
+		clusterIPAllocationErrors.WithLabelValues(label.String()).Inc()
+
+		return nil, ErrFull
+	}
+	// update metrics
+	clusterIPAllocations.WithLabelValues(label.String()).Inc()
+	clusterIPAllocated.WithLabelValues(label.String()).Set(float64(r.Used()))
+	clusterIPAvailable.WithLabelValues(label.String()).Set(float64(r.Free()))
+
+	return netutils.AddIPOffset(r.base, offset), nil
+}
+
+// Release releases the IP back to the pool. Releasing an
+// unallocated IP or an IP out of the range is a no-op and
+// returns no error.
+func (r *Range) Release(ip net.IP) error {
+	return r.release(ip, dryRunFalse)
+}
+
+func (r *Range) release(ip net.IP, dryRun bool) error {
+	ok, offset := r.contains(ip)
+	if !ok {
+		return nil
+	}
+	if dryRun {
+		return nil
+	}
+
+	err := r.alloc.Release(offset)
+	if err == nil {
+		// update metrics
+		label := r.CIDR()
+		clusterIPAllocated.WithLabelValues(label.String()).Set(float64(r.Used()))
+		clusterIPAvailable.WithLabelValues(label.String()).Set(float64(r.Free()))
+	}
+	return err
+}
+
+// ForEach calls the provided function for each allocated IP.
+func (r *Range) ForEach(fn func(net.IP)) {
+	r.alloc.ForEach(func(offset int) {
+		ip, _ := netutils.GetIndexedIP(r.net, offset+1) // +1 because Range doesn't store IP 0
+		fn(ip)
+	})
+}
+
+// Has returns true if the provided IP is already allocated and a call
+// to Allocate(ip) would fail with ErrAllocated.
+func (r *Range) Has(ip net.IP) bool {
+	ok, offset := r.contains(ip)
+	if !ok {
+		return false
+	}
+
+	return r.alloc.Has(offset)
+}
+
+// IPFamily returns the IP family of this range.
+func (r *Range) IPFamily() corev1.IPFamily {
+	return r.family
+}
+
+// Snapshot saves the current state of the pool.
+func (r *Range) Snapshot(dst *api.RangeAllocation) error {
+	snapshottable, ok := r.alloc.(allocator.Snapshottable)
+	if !ok {
+		return fmt.Errorf("not a snapshottable allocator")
+	}
+	rangeString, data := snapshottable.Snapshot()
+	dst.Range = rangeString
+	dst.Data = data
+	return nil
+}
+
+// Restore restores the pool to the previously captured state. ErrMismatchedNetwork
+// is returned if the provided IPNet range doesn't exactly match the previous range.
+func (r *Range) Restore(net *net.IPNet, data []byte) error {
+	if !net.IP.Equal(r.net.IP) || net.Mask.String() != r.net.Mask.String() {
+		return ErrMismatchedNetwork
+	}
+	snapshottable, ok := r.alloc.(allocator.Snapshottable)
+	if !ok {
+		return fmt.Errorf("not a snapshottable allocator")
+	}
+	if err := snapshottable.Restore(net.String(), data); err != nil {
+		return fmt.Errorf("restoring snapshot encountered %v", err)
+	}
+	return nil
+}
+
+// contains returns true and the offset if the ip is in the range, and false
+// and nil otherwise. The first and last addresses of the CIDR are omitted.
+func (r *Range) contains(ip net.IP) (bool, int) {
+	if !r.net.Contains(ip) {
+		return false, 0
+	}
+
+	offset := calculateIPOffset(r.base, ip)
+	if offset < 0 || offset >= r.max {
+		return false, 0
+	}
+	return true, offset
+}
+
+// calculateIPOffset calculates the integer offset of ip from base such that
+// base + offset = ip. It requires ip >= base.
+func calculateIPOffset(base *big.Int, ip net.IP) int {
+	return int(big.NewInt(0).Sub(netutils.BigForIP(ip), base).Int64())
+}
+
+// dryRunRange is a shim to satisfy Interface without persisting state.
+type dryRunRange struct {
+	real *Range
+}
+
+func (dry dryRunRange) Allocate(ip net.IP) error {
+	return dry.real.allocate(ip, dryRunTrue)
+}
+
+func (dry dryRunRange) AllocateNext() (net.IP, error) {
+	return dry.real.allocateNext(dryRunTrue)
+}
+
+func (dry dryRunRange) Release(ip net.IP) error {
+	return dry.real.release(ip, dryRunTrue)
+}
+
+func (dry dryRunRange) ForEach(cb func(net.IP)) {
+	dry.real.ForEach(cb)
+}
+
+func (dry dryRunRange) CIDR() net.IPNet {
+	return dry.real.CIDR()
+}
+
+func (dry dryRunRange) IPFamily() corev1.IPFamily {
+	return dry.real.IPFamily()
+}
+
+func (dry dryRunRange) DryRun() Interface {
+	return dry
+}
+
+func (dry dryRunRange) Has(ip net.IP) bool {
+	return dry.real.Has(ip)
+}

--- a/pkg/route/ipallocator/metrics.go
+++ b/pkg/route/ipallocator/metrics.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipallocator
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "kube_apiserver"
+	subsystem = "clusterip_allocator"
+)
+
+var (
+	// clusterIPAllocated indicates the amount of cluster IP allocated by Service CIDR.
+	clusterIPAllocated = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "allocated_ips",
+			Help:           "Gauge measuring the number of allocated IPs for Services",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"cidr"},
+	)
+	// clusterIPAvailable indicates the amount of cluster IP available by Service CIDR.
+	clusterIPAvailable = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "available_ips",
+			Help:           "Gauge measuring the number of available IPs for Services",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"cidr"},
+	)
+	// clusterIPAllocation counts the total number of ClusterIP allocation.
+	clusterIPAllocations = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "allocation_total",
+			Help:           "Number of Cluster IPs allocations",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"cidr"},
+	)
+	// clusterIPAllocationErrors counts the number of error trying to allocate a ClusterIP.
+	clusterIPAllocationErrors = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "allocation_errors_total",
+			Help:           "Number of errors trying to allocate Cluster IPs",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"cidr"},
+	)
+)
+
+var registerMetricsOnce sync.Once
+
+func registerMetrics() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(clusterIPAllocated)
+		legacyregistry.MustRegister(clusterIPAvailable)
+		legacyregistry.MustRegister(clusterIPAllocations)
+		legacyregistry.MustRegister(clusterIPAllocationErrors)
+	})
+}


### PR DESCRIPTION
This pull request will:

* eliminate the k8s.io/kubernetes dependency from `pkg/route`
* remove `legacyschema` as the event recorder is not used/wired anyway

This should make it much easier to pull this package out (to library-go) and consume later in projects like microshift.