### PR TITLE
[OCPNODE-1258] update runtime-utils for idms migrations

### DIFF
--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -2157,6 +2157,8 @@ func newFakeBuildController(buildClient buildv1client.Interface, imageClient ima
 		ImageStreamInformer:                imageInformers.Image().V1().ImageStreams(),
 		ProxyConfigInformer:                configInformers.Config().V1().Proxies(),
 		ImageContentSourcePolicyInformer:   operatorInformers.Operator().V1alpha1().ImageContentSourcePolicies(),
+		ImageDigestMirrorSetInformer:       configInformers.Config().V1().ImageDigestMirrorSets(),
+		ImageTagMirrorSetInformer:          configInformers.Config().V1().ImageTagMirrorSets(),
 		PodInformer:                        kubeExternalInformers.Core().V1().Pods(),
 		SecretInformer:                     kubeExternalInformers.Core().V1().Secrets(),
 		ConfigMapInformer:                  kubeExternalInformers.Core().V1().ConfigMaps(),

--- a/pkg/cmd/controller/build.go
+++ b/pkg/cmd/controller/build.go
@@ -50,6 +50,8 @@ func RunBuildController(ctx *ControllerContext) (bool, error) {
 	controllerManagerConfigMapInformer := ctx.ControllerManagerKubeInformers.Core().V1().ConfigMaps()
 	proxyCfgInformer := ctx.ConfigInformers.Config().V1().Proxies()
 	imageContentSourcePolicyInformer := ctx.OperatorInformers.Operator().V1alpha1().ImageContentSourcePolicies()
+	imageDigestMirrorSetInformer := ctx.ConfigInformers.Config().V1().ImageDigestMirrorSets()
+	imageTagMirrorSetInformer := ctx.ConfigInformers.Config().V1().ImageTagMirrorSets()
 
 	fg := ctx.OpenshiftControllerConfig.FeatureGates
 	csiVolumesEnabled := false
@@ -76,6 +78,8 @@ func RunBuildController(ctx *ControllerContext) (bool, error) {
 		ControllerManagerConfigMapInformer: controllerManagerConfigMapInformer,
 		ProxyConfigInformer:                proxyCfgInformer,
 		ImageContentSourcePolicyInformer:   imageContentSourcePolicyInformer,
+		ImageDigestMirrorSetInformer:       imageDigestMirrorSetInformer,
+		ImageTagMirrorSetInformer:          imageTagMirrorSetInformer,
 		KubeClient:                         externalKubeClient,
 		BuildClient:                        buildClient,
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{


### PR DESCRIPTION
The epic is planned for 4.14: https://issues.redhat.com/browse/OCPNODE-1258
Update function signature from runtime-utils with idms, itms support. The [OCPNODE-521](https://issues.redhat.com//browse/OCPNODE-521) will land
new CRDs for image mirror configurations for 4.13.
The current components rely on ICSP should use new APIs.
   
ImageDigestMirrorSet implemented: openshift/machine-config-operator#3037
ImageDigestMirrorSet epic: https://issues.redhat.com/browse/OCPNODE-521