### PR TITLE
update the deploy pod to provide failure in pod

### DIFF
--- a/pkg/apps/deployer/deployer_controller.go
+++ b/pkg/apps/deployer/deployer_controller.go
@@ -401,12 +401,13 @@ func (c *DeploymentController) makeDeployerPod(deployment *corev1.ReplicationCon
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:      "deployment",
-					Command:   container.Command,
-					Args:      container.Args,
-					Image:     container.Image,
-					Env:       envVars,
-					Resources: deploymentConfig.Spec.Strategy.Resources,
+					Name:                     "deployment",
+					Command:                  container.Command,
+					Args:                     container.Args,
+					Image:                    container.Image,
+					Env:                      envVars,
+					Resources:                deploymentConfig.Spec.Strategy.Resources,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,

--- a/pkg/apps/deployer/deployer_controller_test.go
+++ b/pkg/apps/deployer/deployer_controller_test.go
@@ -1148,6 +1148,7 @@ func TestMakeDeployerPod(t *testing.T) {
 				p.Spec.Containers[0].Env = append(p.Spec.Containers[0].Env, corev1.EnvVar{Name: "OPENSHIFT_DEPLOYMENT_NAMESPACE", Value: "default"})
 				p.Spec.Containers[0].Resources = container.Resources
 				p.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+				p.Spec.Containers[0].TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 
 				p.Spec.DNSPolicy = "None"
 				p.Spec.DNSConfig = &corev1.PodDNSConfig{


### PR DESCRIPTION
While debugging a deployer pod problem, I couldn't find the message I needed.  This leaves the current file location alone and it will continue to be used if present, but without it, the sysout will be used.

/assign @soltysh 