### PR TITLE
BUILD-558: Easier to Use Buildpacks on OpenShift Builds (Custom Strategy)

### DIFF
--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -77,19 +77,19 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	}
 
 	// expected volumes:
-	// buildworkdir
-	// blobs meta cache
-	// pushsecret
-	// pullsecret
-	// inputsecret
-	// inputconfigmap
-	// build-system-config
-	// certificate authorities
-	// container storage
-	// container run
-	// blobs content cache
-	// global CA injection configmap
-	// node pull secrets
+	//  - buildworkdir
+	//  - blobs meta cache
+	//  - pushsecret
+	//  - pullsecret
+	//  - inputsecret
+	//  - inputconfigmap
+	//  - build-system-config
+	//  - certificate authorities
+	//  - container storage
+	//  - container run
+	//  - blobs content cache
+	//  - global CA injection configmap
+	//  - node pull secrets
 	if len(container.VolumeMounts) != 13 {
 		t.Fatalf("Expected 13 volumes in container, got %d", len(container.VolumeMounts))
 	}

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -117,19 +117,19 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	}
 
 	// expected volumes:
-	// node pull secrets
-	// buildworkdir
-	// blobs meta cache
-	// pushsecret
-	// pullsecret
-	// inputsecret
-	// inputconfigmap
-	// build-system-configmap
-	// certificate authorities
-	// container storage
-	// container run
-	// blobs content cache
-	// global CA injection configmap
+	//  - node pull secrets
+	//  - buildworkdir
+	//  - blobs meta cache
+	//  - pushsecret
+	//  - pullsecret
+	//  - inputsecret
+	//  - inputconfigmap
+	//  - build-system-configmap
+	//  - certificate authorities
+	//  - container storage
+	//  - container run
+	//  - blobs content cache
+	//  - global CA injection configmap
 	if len(container.VolumeMounts) != 13 {
 		t.Fatalf("Expected 13 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
 	}

--- a/pkg/cmd/controller/build.go
+++ b/pkg/cmd/controller/build.go
@@ -72,7 +72,9 @@ func RunBuildController(ctx *ControllerContext) (bool, error) {
 			Image:          imageTemplate.ExpandOrDie("docker-builder"),
 			SecurityClient: securityClient.SecurityV1(),
 		},
-		CustomBuildStrategy:      &buildstrategy.CustomBuildStrategy{},
+		CustomBuildStrategy: &buildstrategy.CustomBuildStrategy{
+			Image: imageTemplate.ExpandOrDie("docker-builder"),
+		},
 		BuildDefaults:            builddefaults.BuildDefaults{Config: ctx.OpenshiftControllerConfig.Build.BuildDefaults},
 		BuildOverrides:           buildoverrides.BuildOverrides{Config: ctx.OpenshiftControllerConfig.Build.BuildOverrides},
 		InternalRegistryHostname: ctx.OpenshiftControllerConfig.DockerPullSecret.InternalRegistryHostname,


### PR DESCRIPTION
Custom Build Strategy (for Buildpacks)
--------------------------------------

This pull request changes the `BuildConfig` Custom strategy ([BUILD-558](https://issues.redhat.com//browse/BUILD-558)) to make simpler to run a custom party image builder.

The [testing](#testing) section shows how to employ a [Cloud Native Builder (CNB)][customBuilder], which still needs to [intervene and prepare the container][customBuilderEntrypoint] before being able to run the build lifecycle process.

The section ["Next Steps"](#next-steps) shares some ideas for the upcoming interactions to improve the developer experience.

# Pull-Request Changes

## Git-Clone Init-Container

Following `Source` and `Docker` strategies, the source-code is cloned using a init-container and exposed in the build POD using a `emptyDir: {}` volume, shared between containers.

### Writable Working Directory

Additionally, the `workingDir` is set to `/tmp/build/inputs` and the directory is made writable, the location used for the Git-Clone process is a shared `emptyDir: {} ` mount.

The [example application][otaviofNodejsEx] is based on Node.js meaning during the regular build process the directories `node_modules` will be created. It's a common use case having the (temporary) working directory on read/write mode.

## `OUTPUT_REGISTRY_IMAGE`

The fully qualified output image name is informed by the Build controller to the custom builder, a small modification to avoid it on the custom builder process.

# Next Steps

Sharing some ideas out loud to gather early feedback.

## Script Section

At least a few tweaks will have to take place before being able to invoke the custom builder, like for instance, when [using the internal container registry with self signed certificates][customBuilderCATrust] the builder images needs to add the CA to the local trust.

The most simplistic approach to Paketo's CNB, taking in considering this PR, is:

```yaml
---
apiVersion: build.openshift.io/v1
kind: BuildConfig
spec:
  strategy:
    type: Custom
    customStrategy:
      script: |
        /cnb/lifecycle/creator -app="." "${OUTPUT_REGISTRY_IMAGE}"
```

The `.spec.strategy.customStrategy.script` helps the users to setup the build enviornment and empower using third party tools directly on the `BuildConfig` resource.

## Deprecate `exposeDockerSocket`

We should stop allowing the access to the node's docker-socket by all means, the attribute `.spec.strategy.customStrategy.exposeDockerSocket` should be deprecated as soon as possible.

OpenShift should focus the Custom strategy to non-privileged builds only.

## Unprivileged Builds by Default

OpenShift Builds Custom strategy should have non-privileged by default, the `BUILD_PRIVILEGED` environment variable should have its default set to `false`.

This improves the developer experience and also makes the recommended approach easier to addopt.

## Custom Strategy on `new-app` Workflow

Currently `oc new-app` (or `new-build`) do not support Custom strategy, we should improve the command line tool to support this style of builds as well. For instance:

```bash
oc new-app docker.io/paketobuildpacks/builder:base~https://github.com/otaviof/nodejs-ex.git \
    --name="nodejs-ex" \
    --strategy="custom" \
    --env="CNB_PLATFORM_API=0.10" \
    --custom-script='/cnb/lifecycle/creator -app="." "${OUTPUT_REGISTRY_IMAGE}"'
```

The most important aspects in this example are related to the ability to define the `.spec.strategy.customStrategy.from.name` and `.spec.strategy.customStrategy.script` attributes.

Most of the heavy lifting is already in place.

# Testing

## Buildpacks CNB

The [`os-custom-paketo-builder` image][customBuilder] is the example implementation of a custom Buildpacks CNB for OpenShift, it takes care of setting the stage before running the Buildpacks Lifecycle.

Make sure the `ImageStream` is available by following the [repository documentation][customBuilder].

## `BuildConfig`

Follow the steps in the [custom CNB image repository][customBuilderOpenShift] to create the `ImageStreams`, configure the registry authentication and allow `anyuid` SCC.

Then, apply the `BuildConfig` resource:

```bash
oc apply -f https://github.com/otaviof/os-custom-paketo-builder/blob/main/os/buildconfig.yaml
```

Finally, start the build:

```bash
oc start-build nodejs-ex --follow --wait
```

The Node.js application build is going to be ready for [deploying it too][customBuilderDeployment].

[customBuilder]: https://github.com/otaviof/os-custom-paketo-builder/
[customBuilderCATrust]: https://github.com/otaviof/os-custom-paketo-builder/blob/01a9291577b358fdc6fb70a952936073e6649883/build.sh#L49-L60
[customBuilderDeployment]: https://github.com/otaviof/os-custom-paketo-builder/blob/main/os/README.md#deploying
[customBuilderEntrypoint]: https://github.com/otaviof/os-custom-paketo-builder/blob/main/build.sh
[customBuilderOpenShift]: https://github.com/otaviof/os-custom-paketo-builder/blob/main/os/README.md
[otaviofNodejsEx]: https://github.com/otaviof/nodejs-ex