### PR TITLE
OCPBUGS-10588: mount build.Spec.Source.ConfigMaps for custom builder images

### DIFF
--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -132,6 +132,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	setOwnerReference(pod, build)
 	setupSourceSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.SourceSecret)
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
+	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
 	setupAdditionalSecrets(pod, &pod.Spec.Containers[0], build.Spec.Strategy.CustomStrategy.Secrets)
 	setupContainersConfigs(build, pod)
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)


### PR DESCRIPTION
When using a custom build strategy, mount config maps which were listed as sources, like we do for docker and sti builds.