### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,11 +3,8 @@ reviewers:
   - mfojtik
   - soltysh
   - csrwng
-  - coreydaley
-  - divyansh42
 approvers:
   - bparees
   - mfojtik
   - soltysh
-  - coreydaley
 component: openshift-controller-manager


### PR DESCRIPTION
Remove Pipeline Integrations team members from main OWNERS file as we only own the build section.