### PR TITLE
OCPBUGS-18498: Disable Build and DeploymentConfig Informers if their caps are disabled

### DIFF
--- a/pkg/cmd/controller/interfaces.go
+++ b/pkg/cmd/controller/interfaces.go
@@ -171,8 +171,12 @@ func (c *ControllerContext) StartInformers(stopCh <-chan struct{}) {
 	c.OpenshiftConfigKubernetesInformers.Start(stopCh)
 	c.ControllerManagerKubeInformers.Start(stopCh)
 
-	c.AppsInformers.Start(stopCh)
-	c.BuildInformers.Start(stopCh)
+	if c.IsControllerEnabled(string(openshiftcontrolplanev1.OpenshiftDeploymentConfigController)) {
+		c.AppsInformers.Start(stopCh)
+	}
+	if c.IsControllerEnabled(string(openshiftcontrolplanev1.OpenshiftBuildController)) {
+		c.BuildInformers.Start(stopCh)
+	}
 	c.ConfigInformers.Start(stopCh)
 	c.ImageInformers.Start(stopCh)
 

--- a/pkg/cmd/controller/template.go
+++ b/pkg/cmd/controller/template.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
+	buildv1client "github.com/openshift/client-go/build/clientset/versioned"
 	templatecontroller "github.com/openshift/openshift-controller-manager/pkg/template/controller"
 	"k8s.io/client-go/dynamic"
 )
@@ -17,12 +19,17 @@ func RunTemplateInstanceController(ctx *ControllerContext) (bool, error) {
 		return true, err
 	}
 
+	var buildClient buildv1client.Interface
+	if ctx.IsControllerEnabled(string(openshiftcontrolplanev1.OpenshiftBuildController)) {
+		buildClient = ctx.ClientBuilder.OpenshiftBuildClientOrDie(saName)
+	}
+
 	go templatecontroller.NewTemplateInstanceController(
 		ctx.RestMapper,
 		dynamicClient,
 		ctx.ClientBuilder.ClientOrDie(saName).AuthorizationV1(),
 		ctx.ClientBuilder.ClientOrDie(saName),
-		ctx.ClientBuilder.OpenshiftBuildClientOrDie(saName),
+		buildClient,
 		ctx.ClientBuilder.OpenshiftTemplateClientOrDie(saName).TemplateV1(),
 		ctx.TemplateInformers.Template().V1().TemplateInstances(),
 	).Run(5, ctx.Stop)

--- a/pkg/template/controller/readiness.go
+++ b/pkg/template/controller/readiness.go
@@ -282,6 +282,9 @@ func CheckReadiness(oc buildv1client.Interface, ref corev1.ObjectReference, obj 
 
 	switch ref.GroupVersionKind() {
 	case groupVersionKind(buildv1.GroupVersion, "BuildConfig"), schema.GroupVersionKind{Group: "", Version: "v1", Kind: "BuildConfig"}:
+		if oc == nil {
+			return false, false, nil
+		}
 		return checkBuildConfigReadiness(oc, castObj)
 	}
 


### PR DESCRIPTION
We don't run Build and DeploymentConfig controllers, if their capabilities are disabled. Whereas, ImageTrigger controller also relies on these resources in the form of informers and these informers are getting cached timeout error and causing the controller-manager being restarted multiple times.

This PR disables build and deploymentconfig informers, in cases where their caps are disabled to let imagetrigger can work properly.

This PR is continuation of this https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/299