### PR TITLE
OCPBUGS-23175: [release-4.11] fix template namespace processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openshift/api v0.0.0-20220616165336-689617d54300
 	github.com/openshift/build-machinery-go v0.0.0-20220429084610-baff9f8d23b3
 	github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf
-	github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c
+	github.com/openshift/library-go v0.0.0-20231031183916-46d900b16f01
 	github.com/openshift/runtime-utils v0.0.0-20220513161558-c736ec4e99ce
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -709,8 +709,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220429084610-baff9f8d23b3 h1:M7
 github.com/openshift/build-machinery-go v0.0.0-20220429084610-baff9f8d23b3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf h1:gAYYPWVduONFJ6yuczLleApk0nEH3W0GgxDX2+O+B9E=
 github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
-github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c h1:Z0uVzdNHQfbCpP498tAE53sh84ILdOj4H1LyJv465c8=
-github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
+github.com/openshift/library-go v0.0.0-20231031183916-46d900b16f01 h1:X7HnG+tDcWhNKC9k3ZO88amQNAcSXV2Qfad9aA6UmrQ=
+github.com/openshift/library-go v0.0.0-20231031183916-46d900b16f01/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/openshift/runtime-utils v0.0.0-20220513161558-c736ec4e99ce h1:5FkMWI3gGvgjxOHhynvABPtkqY/NnSgfJk9joYr7feA=
 github.com/openshift/runtime-utils v0.0.0-20220513161558-c736ec4e99ce/go.mod h1:KrTGRRSRHZT4vbXfPptzbhnsksLDkJj0J2Ha/mfDbUw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -411,6 +411,10 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 
 	templatePtr := &templateInstance.Spec.Template
 	template := templatePtr.DeepCopy()
+	if len(template.Namespace) == 0 {
+		// api servers now (k8s 1.25) care that the namespace actually match the target namespace
+		template.Namespace = templateInstance.Namespace
+	}
 
 	if secret != nil {
 		for i, param := range template.Parameters {

--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -399,13 +399,13 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 			Resource:  "secrets",
 			Name:      templateInstance.Spec.Secret.Name,
 		}); err != nil {
-			return err
+			return fmt.Errorf("unable to authorize user to retrive TemplateInstance Secret: %w", err)
 		}
 
 		s, err := c.kc.CoreV1().Secrets(templateInstance.Namespace).Get(context.TODO(), templateInstance.Spec.Secret.Name, metav1.GetOptions{})
 		secret = s
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to retrieve TemplateInstance Secret: %w", err)
 		}
 	}
 
@@ -432,18 +432,18 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 		Resource:  "templateconfigs",
 		Name:      template.Name,
 	}); err != nil {
-		return err
+		return fmt.Errorf("unable to authorize user to create TemplateConfig : %w", err)
 	}
 
 	klog.V(4).Infof("TemplateInstance controller: creating TemplateConfig for %s/%s", templateInstance.Namespace, templateInstance.Name)
 
 	v1Template, err := legacyscheme.Scheme.ConvertToVersion(template, templatev1.GroupVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to convert template to %s.%s.Template: %w", templatev1.GroupName, templatev1.GroupVersion, err)
 	}
 	processedObjects, err := templateprocessingclient.NewDynamicTemplateProcessor(c.dynamicClient).ProcessToList(v1Template.(*templatev1.Template))
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to process Template objects: %w", err)
 	}
 
 	for _, obj := range processedObjects.Items {
@@ -458,17 +458,17 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 	// First, do all the SARs to ensure the requester actually has permissions
 	// to create.
 	klog.V(4).Infof("TemplateInstance controller: running SARs for %s/%s", templateInstance.Namespace, templateInstance.Name)
-	allErrors := []error{}
+	var allErrors []error
 	for _, currObj := range processedObjects.Items {
-		restMapping, mappingErr := c.dynamicRestMapper.RESTMapping(currObj.GroupVersionKind().GroupKind(), currObj.GroupVersionKind().Version)
-		if mappingErr != nil {
-			allErrors = append(allErrors, mappingErr)
+		restMapping, err := c.dynamicRestMapper.RESTMapping(currObj.GroupVersionKind().GroupKind(), currObj.GroupVersionKind().Version)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("unable to identify the resource mapping for %s: %w", currObj.GroupVersionKind(), err))
 			continue
 		}
 
-		namespace, nsErr := c.processNamespace(templateInstance.Namespace, currObj.GetNamespace(), restMapping.Scope.Name() == meta.RESTScopeNameRoot)
-		if nsErr != nil {
-			allErrors = append(allErrors, nsErr)
+		namespace, err := c.processNamespace(templateInstance.Namespace, currObj.GetNamespace(), restMapping.Scope.Name() == meta.RESTScopeNameRoot)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("error processing namespace for %s, Name=%s:%w", currObj.GroupVersionKind(), currObj.GetName(), err))
 			continue
 		}
 
@@ -479,7 +479,7 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 			Resource:  restMapping.Resource.Resource,
 			Name:      currObj.GetName(),
 		}); err != nil {
-			allErrors = append(allErrors, err)
+			allErrors = append(allErrors, fmt.Errorf("unable to authorize user to create %s, Name=%s: %w", restMapping.Resource, currObj.GetName(), err))
 			continue
 		}
 	}
@@ -491,25 +491,25 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 	// labelled as having previously been created by us.
 	klog.V(4).Infof("TemplateInstance controller: creating objects for %s/%s", templateInstance.Namespace, templateInstance.Name)
 	templateInstance.Status.Objects = nil
-	allErrors = []error{}
+	allErrors = nil
 	for _, currObj := range processedObjects.Items {
-		restMapping, mappingErr := c.dynamicRestMapper.RESTMapping(currObj.GroupVersionKind().GroupKind(), currObj.GroupVersionKind().Version)
-		if mappingErr != nil {
-			allErrors = append(allErrors, mappingErr)
+		restMapping, err := c.dynamicRestMapper.RESTMapping(currObj.GroupVersionKind().GroupKind(), currObj.GroupVersionKind().Version)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("unable to identify the resource mapping for %s: %w", currObj.GroupVersionKind(), err))
 			continue
 		}
 
-		namespace, nsErr := c.processNamespace(templateInstance.Namespace, currObj.GetNamespace(), restMapping.Scope.Name() == meta.RESTScopeNameRoot)
-		if nsErr != nil {
-			allErrors = append(allErrors, nsErr)
+		namespace, err := c.processNamespace(templateInstance.Namespace, currObj.GetNamespace(), restMapping.Scope.Name() == meta.RESTScopeNameRoot)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("error processing namespace for %s, Name=%s:%w", currObj.GroupVersionKind(), currObj.GetName(), err))
 			continue
 		}
 
-		createObj, createErr := c.dynamicClient.Resource(restMapping.Resource).Namespace(namespace).Create(context.TODO(), &currObj, metav1.CreateOptions{})
-		if kerrors.IsAlreadyExists(createErr) {
+		createObj, err := c.dynamicClient.Resource(restMapping.Resource).Namespace(namespace).Create(context.TODO(), &currObj, metav1.CreateOptions{})
+		if kerrors.IsAlreadyExists(err) {
 			freshGottenObj, getErr := c.dynamicClient.Resource(restMapping.Resource).Namespace(namespace).Get(context.TODO(), currObj.GetName(), metav1.GetOptions{})
 			if getErr != nil {
-				allErrors = append(allErrors, getErr)
+				allErrors = append(allErrors, fmt.Errorf("unable to retrive existing %s, Name=%s: %w", restMapping.Resource, currObj.GetName(), getErr))
 				continue
 			}
 
@@ -517,14 +517,11 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templatev1.Te
 			// if the labels match, it's already our object so pretend we created
 			// it successfully.
 			if ok && owner == string(templateInstance.UID) {
-				createObj, createErr = freshGottenObj, nil
-			} else {
-				allErrors = append(allErrors, createErr)
-				continue
+				createObj, err = freshGottenObj, nil
 			}
 		}
-		if createErr != nil {
-			allErrors = append(allErrors, createErr)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("unable to create %s, Name=%s: %w", restMapping.Resource, currObj.GetName(), err))
 			continue
 		}
 

--- a/vendor/github.com/openshift/library-go/pkg/template/templateprocessingclient/dynamic_process.go
+++ b/vendor/github.com/openshift/library-go/pkg/template/templateprocessingclient/dynamic_process.go
@@ -38,13 +38,19 @@ func (c *dynamicTemplateProcessor) ProcessToList(template *templatev1.Template) 
 	return c.ProcessToListFromUnstructured(&unstructured.Unstructured{Object: unstructuredTemplate})
 }
 
-func (c *dynamicTemplateProcessor) ProcessToListFromUnstructured(unstructuredTemplate *unstructured.Unstructured) (*unstructured.UnstructuredList, error) {
+func (c *dynamicTemplateProcessor) ProcessToListFromUnstructured(unstructuredTemplateFromCaller *unstructured.Unstructured) (*unstructured.UnstructuredList, error) {
+	// avoid mutating input
+	unstructuredTemplate := unstructuredTemplateFromCaller.DeepCopy()
+	unstructuredTemplate.SetNamespace("default")
+
 	processedTemplate, err := c.client.Resource(templatev1.GroupVersion.WithResource("processedtemplates")).
 		Namespace("default").Create(context.TODO(), unstructuredTemplate, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
+	// reset the namespace as before
+	processedTemplate.SetNamespace(unstructuredTemplateFromCaller.GetNamespace())
 	// convert the template into something we iterate over as a list
 	if err := unstructured.SetNestedField(processedTemplate.Object, processedTemplate.Object["objects"], "items"); err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -442,7 +442,7 @@ github.com/openshift/client-go/template/informers/externalversions/internalinter
 github.com/openshift/client-go/template/informers/externalversions/template
 github.com/openshift/client-go/template/informers/externalversions/template/v1
 github.com/openshift/client-go/template/listers/template/v1
-# github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c
+# github.com/openshift/library-go v0.0.0-20231031183916-46d900b16f01
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/apps/appsserialization
 github.com/openshift/library-go/pkg/apps/appsutil


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-controller-manager/pull/242 to release-4.11. It includes changes from https://github.com/openshift/library-go/pull/1598.

For context, this is required to fix templateinstance tests failures from https://github.com/openshift/openshift-apiserver/pull/400.
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_openshift-apiserver/400/pull-ci-openshift-openshift-apiserver-release-4.11-e2e-aws/1719006784351375360