### PR TITLE
BUILD-725: Adds build & deployer controller

### DIFF
--- a/pkg/authorization/defaultrolebindings/project_policy_test.go
+++ b/pkg/authorization/defaultrolebindings/project_policy_test.go
@@ -1,0 +1,47 @@
+package defaultrolebindings
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestRoleBindingsForController(t *testing.T) {
+	tests := map[string]struct {
+		controller                string
+		expectedRoleBindingsNames sets.Set[string]
+	}{
+		"test-builder": {
+			controller:                "BuilderRoleBindingController",
+			expectedRoleBindingsNames: sets.Set[string]{"system:image-builders": {}},
+		},
+		"test-deployer": {
+			controller:                "DeployerRoleBindingController",
+			expectedRoleBindingsNames: sets.Set[string]{"system:deployers": {}},
+		},
+		"test-image-puller": {
+			controller:                "ImagePullerRoleBindingController",
+			expectedRoleBindingsNames: sets.Set[string]{"system:image-pullers": {}},
+		},
+		"test-default": {
+			controller: "DefaultRoleBindingController",
+			expectedRoleBindingsNames: sets.Set[string]{"system:image-pullers": {},
+				"system:image-builders": {},
+				"system:deployers":      {},
+			},
+		},
+	}
+
+	for tName, tCase := range tests {
+		t.Run(tName, func(t *testing.T) {
+			controllerRoleBindings := GetRoleBindingsForController(tCase.controller)
+			roleBindingNames := GetBootstrapServiceAccountProjectRoleBindingNames(controllerRoleBindings)
+
+			if !cmp.Equal(roleBindingNames, tCase.expectedRoleBindingsNames) {
+				t.Fatalf("expected %v, got %#v", tCase.expectedRoleBindingsNames, roleBindingNames)
+			}
+
+		})
+	}
+}

--- a/pkg/cmd/controller/authorization.go
+++ b/pkg/cmd/controller/authorization.go
@@ -1,6 +1,9 @@
 package controller
 
-import "github.com/openshift/openshift-controller-manager/pkg/authorization/defaultrolebindings"
+import (
+	"github.com/openshift/openshift-controller-manager/pkg/authorization/defaultrolebindings"
+	"k8s.io/client-go/kubernetes"
+)
 
 func RunDefaultRoleBindingController(ctx *ControllerContext) (bool, error) {
 	kubeClient, err := ctx.ClientBuilder.Client(infraDefaultRoleBindingsControllerServiceAccountName)
@@ -8,11 +11,52 @@ func RunDefaultRoleBindingController(ctx *ControllerContext) (bool, error) {
 		return true, err
 	}
 
-	go defaultrolebindings.NewDefaultRoleBindingsController(
-		ctx.KubernetesInformers.Rbac().V1().RoleBindings(),
-		ctx.KubernetesInformers.Core().V1().Namespaces(),
+	return runRoleBindingController(ctx, kubeClient, "DefaultRoleBindingController")
+}
+
+func RunBuilderRoleBindingController(ctx *ControllerContext) (bool, error) {
+	// Role binding controllers currently share the same service account,
+	// as these are created by "bootstrap" logic located elsewhere in Openshift.
+	// TODO: Refactor the controller service accounts to be managed by openshift-controller-manager-operator.
+	kubeClient, err := ctx.ClientBuilder.Client(infraDefaultRoleBindingsControllerServiceAccountName)
+	if err != nil {
+		return true, err
+	}
+
+	return runRoleBindingController(ctx, kubeClient, "BuilderRoleBindingController")
+}
+
+func RunDeployerRoleBindingController(ctx *ControllerContext) (bool, error) {
+	// Role binding controllers currently share the same service account,
+	// as these are created by "bootstrap" logic located elsewhere in Openshift.
+	// TODO: Refactor the controller service accounts to be managed by openshift-controller-manager-operator.
+	kubeClient, err := ctx.ClientBuilder.Client(infraDefaultRoleBindingsControllerServiceAccountName)
+	if err != nil {
+		return true, err
+	}
+
+	return runRoleBindingController(ctx, kubeClient, "DeployerRoleBindingController")
+}
+
+func RunImagePullerRoleBindingController(ctx *ControllerContext) (bool, error) {
+	// Role binding controllers currently share the same service account,
+	// as these are created by "bootstrap" logic located elsewhere in Openshift.
+	// TODO: Refactor the controller service accounts to be managed by openshift-controller-manager-operator.
+	kubeClient, err := ctx.ClientBuilder.Client(infraDefaultRoleBindingsControllerServiceAccountName)
+	if err != nil {
+		return true, err
+	}
+
+	return runRoleBindingController(ctx, kubeClient, "ImagePullerRoleBindingController")
+}
+
+func runRoleBindingController(cctx *ControllerContext, kubeClient kubernetes.Interface, controllerName string) (bool, error) {
+	go defaultrolebindings.NewRoleBindingsController(
+		cctx.KubernetesInformers.Rbac().V1().RoleBindings(),
+		cctx.KubernetesInformers.Core().V1().Namespaces(),
 		kubeClient.RbacV1(),
-	).Run(5, ctx.Stop)
+		controllerName,
+	).Run(5, cctx.Stop)
 
 	return true, nil
 }


### PR DESCRIPTION
This refactors the current [defaultsRoleBinding controller](https://github.com/openshift/openshift-controller-manager/blob/release-4.13/pkg/authorization/defaultrolebindings/defaultrolebindings.go#L41) into different controllers, responsible for managing respective roleBindings:
- defaultRoleBindingController -> system:image-pullers 
- builderRoleBindingController -> system:image-builders
- deployerRoleBindingController -> system:deployers

Dependent on:
- https://github.com/openshift/api/pull/1770
- https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/335