### PR TITLE
OCPBUGS-31213: Unable to look up the service account secrets for build

### DIFF
--- a/pkg/build/buildutil/util.go
+++ b/pkg/build/buildutil/util.go
@@ -201,7 +201,7 @@ func FetchServiceAccountSecrets(secretStore v1lister.SecretLister, serviceAccoun
 	if err != nil {
 		return result, fmt.Errorf("Error getting push/pull secrets for service account %s/%s: %v", namespace, serviceAccount, err)
 	}
-	for _, ref := range sa.Secrets {
+	for _, ref := range sa.ImagePullSecrets {
 		secret, err := secretStore.Secrets(namespace).Get(ref.Name)
 		if err != nil {
 			continue

--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -2062,7 +2062,7 @@ func fakeKubeExternalClientSet(objects ...runtime.Object) kubernetes.Interface {
 	builderSA := &corev1.ServiceAccount{}
 	builderSA.Name = "builder"
 	builderSA.Namespace = "namespace"
-	builderSA.Secrets = []corev1.ObjectReference{
+	builderSA.ImagePullSecrets = []corev1.LocalObjectReference{
 		{
 			Name: "secret",
 		},


### PR DESCRIPTION
Build is looking for image pull secrets in the **ServiceAccount.Secrets** field, when it should be looking in the **ServiceAccount.ImagePullSecrets** field instead. 

In 4.16 we will stop putting image pull secrets in the **ServiceAccount.Secrets** field.