### PR TITLE
OCPBUGS-32729: Rollback state of managed image pull secrets after downgrade

### DIFF
--- a/pkg/serviceaccounts/controllers/rollback/legacy_image_pull_secret_rollback_controller.go
+++ b/pkg/serviceaccounts/controllers/rollback/legacy_image_pull_secret_rollback_controller.go
@@ -1,0 +1,134 @@
+package rollback
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/exp/slices"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type legacyImagePullSecretRollbackController struct {
+	client     kubernetes.Interface
+	secrets    listers.SecretLister
+	cacheSyncs []cache.InformerSynced
+	queue      workqueue.RateLimitingInterface
+}
+
+func NewLegacyImagePullSecretRollbackController(client kubernetes.Interface, secrets informers.SecretInformer) *legacyImagePullSecretRollbackController {
+	c := &legacyImagePullSecretRollbackController{
+		client:     client,
+		secrets:    secrets.Lister(),
+		cacheSyncs: []cache.InformerSynced{secrets.Informer().HasSynced},
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "legacy-image-pull-secrets"),
+	}
+	secrets.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj any) bool {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			if secret.Type != corev1.SecretTypeDockercfg {
+				// not an image pull secret
+				return false
+			}
+			return slices.Contains(secret.Finalizers, "openshift.io/legacy-token")
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					c.queue.Add(key)
+				}
+			},
+			UpdateFunc: func(_ any, new any) {
+				key, err := cache.MetaNamespaceKeyFunc(new)
+				if err == nil {
+					c.queue.Add(key)
+				}
+			},
+			DeleteFunc: func(obj any) {
+				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				if err == nil {
+					c.queue.Add(key)
+				}
+			},
+		},
+	})
+	return c
+}
+
+func (c *legacyImagePullSecretRollbackController) sync(ctx context.Context, key string) error {
+	klog.V(4).InfoS("sync", "key", key)
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	secret, err := c.secrets.Secrets(ns).Get(name)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	index := slices.Index(secret.Finalizers, "openshift.io/legacy-token")
+	if index < 0 {
+		return nil
+	}
+	patch := fmt.Sprintf(`[`+
+		`{"op": "test", "path": "/metadata/finalizers/%d", "value": "%s"},`+
+		`{"op": "remove", "path": "/metadata/finalizers/%[1]d"}`+
+		`]`, index, "openshift.io/legacy-token")
+	klog.V(1).InfoS("rolling back legacy managed image pull secret", "ns", secret.Namespace, "serviceAccount", secret.Name)
+	_, err = c.client.CoreV1().Secrets(secret.Namespace).Patch(ctx, secret.Name, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
+	return err
+}
+
+func (c *legacyImagePullSecretRollbackController) Run(ctx context.Context, workers int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+	const name = "openshift.io/internal-image-registry-pull-secrets_legacy-image-pull-secret-rollback"
+	klog.InfoS("Starting controller", "name", name)
+	if !cache.WaitForNamedCacheSync(name, ctx.Done(), c.cacheSyncs...) {
+		return
+	}
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+	klog.InfoS("Started controller", "name", name)
+	<-ctx.Done()
+	klog.InfoS("Shutting down controller", "name", name)
+}
+
+func (c *legacyImagePullSecretRollbackController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *legacyImagePullSecretRollbackController) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+	err := c.sync(ctx, key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+	runtime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	c.queue.AddRateLimited(key)
+	return true
+}

--- a/pkg/serviceaccounts/controllers/rollback/legacy_image_pull_secret_rollback_controller_test.go
+++ b/pkg/serviceaccounts/controllers/rollback/legacy_image_pull_secret_rollback_controller_test.go
@@ -1,0 +1,105 @@
+package rollback
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestLegacyImagePullSecretRollbackControllerSync(t *testing.T) {
+
+	secret := func(opts ...func(*corev1.Secret)) *corev1.Secret {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "test"}}
+		for _, f := range opts {
+			f(s)
+		}
+		return s
+	}
+	withFinalizers := func(f ...string) func(*corev1.Secret) {
+		return func(s *corev1.Secret) {
+			s.ObjectMeta.Finalizers = append(s.ObjectMeta.Finalizers, f...)
+		}
+	}
+
+	testCases := []struct {
+		name         string
+		secret       *corev1.Secret
+		cachedSecret *corev1.Secret
+		expected     *corev1.Secret
+		expectErr    bool
+	}{
+		{
+			name:     "no finalizer",
+			secret:   secret(),
+			expected: secret(),
+		},
+		{
+			name:     "with finalizer",
+			secret:   secret(withFinalizers("openshift.io/legacy-token")),
+			expected: secret(),
+		},
+		{
+			name:     "other finalizer",
+			secret:   secret(withFinalizers("test")),
+			expected: secret(withFinalizers("test")),
+		},
+		{
+			name:     "mixed finalizers",
+			secret:   secret(withFinalizers("test", "openshift.io/legacy-token", "test2")),
+			expected: secret(withFinalizers("test", "test2")),
+		},
+		{
+			name:         "cache behind",
+			secret:       secret(withFinalizers("test", "openshift.io/legacy-token", "test2")),
+			cachedSecret: secret(withFinalizers("openshift.io/legacy-token", "test3")),
+			expectErr:    true,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cachedSecret == nil {
+				tc.cachedSecret = tc.secret
+			}
+			client := fake.NewSimpleClientset(tc.secret)
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := indexer.Add(tc.cachedSecret); err != nil {
+				t.Fatal(err)
+			}
+			c := legacyImagePullSecretRollbackController{
+				client:  client,
+				secrets: listers.NewSecretLister(indexer),
+			}
+			err := c.sync(ctx, tc.secret.Namespace+"/"+tc.secret.Name)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatal(err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatal("expected error")
+			}
+			actual, err := client.CoreV1().Secrets(tc.secret.Namespace).Get(ctx, tc.secret.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !equality.Semantic.DeepEqual(tc.expected, actual) {
+				if len(actual.Finalizers) == 0 {
+					// normalize
+					actual.Finalizers = nil
+				}
+				t.Fatal(cmp.Diff(tc.expected, actual))
+			}
+
+		})
+	}
+}

--- a/pkg/serviceaccounts/controllers/rollback/service_account-rollback-controller.go
+++ b/pkg/serviceaccounts/controllers/rollback/service_account-rollback-controller.go
@@ -1,0 +1,152 @@
+package rollback
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/exp/slices"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type serviceAccountRollbackController struct {
+	client          kubernetes.Interface
+	serviceAccounts listers.ServiceAccountLister
+	secrets         listers.SecretLister
+	cacheSyncs      []cache.InformerSynced
+	queue           workqueue.RateLimitingInterface
+}
+
+func NewServiceAccountRollbackController(kubeclient kubernetes.Interface, serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer) *serviceAccountRollbackController {
+	c := &serviceAccountRollbackController{
+		client:          kubeclient,
+		serviceAccounts: serviceAccounts.Lister(),
+		secrets:         secrets.Lister(),
+		cacheSyncs:      []cache.InformerSynced{serviceAccounts.Informer().HasSynced, secrets.Informer().HasSynced},
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "service-accounts"),
+	}
+
+	serviceAccounts.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj any) bool {
+			sa, ok := obj.(*corev1.ServiceAccount)
+			if !ok {
+				return false
+			}
+			_, ok = sa.Annotations["openshift.io/internal-registry-pull-secret-ref"]
+			return ok
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					c.queue.Add(key)
+				}
+			},
+			UpdateFunc: func(old any, new any) {
+				key, err := cache.MetaNamespaceKeyFunc(new)
+				if err == nil {
+					c.queue.Add(key)
+				}
+			},
+		},
+	})
+	return c
+}
+
+func (c *serviceAccountRollbackController) sync(ctx context.Context, key string) error {
+	klog.V(4).InfoS("sync", "key", key)
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	serviceAccount, err := c.serviceAccounts.ServiceAccounts(ns).Get(name)
+	if kerrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	imagePullSecretName := serviceAccount.Annotations["openshift.io/internal-registry-pull-secret-ref"]
+	ops := []string{
+		`{"op": "remove", "path": "/metadata/annotations/openshift.io~1internal-registry-pull-secret-ref"}`,
+	}
+	var rollbackRefs bool
+	secret, err := c.secrets.Secrets(ns).Get(imagePullSecretName)
+	if kerrors.IsNotFound(err) {
+		rollbackRefs = true
+	} else if err != nil {
+		return err
+	} else if _, ok := secret.Annotations["openshift.io/internal-registry-auth-token.service-account"]; ok {
+		// this image pull secret is from the future
+		rollbackRefs = true
+	}
+	if rollbackRefs {
+		index := slices.IndexFunc(serviceAccount.Secrets, func(ref corev1.ObjectReference) bool {
+			return ref.Name == imagePullSecretName
+		})
+		if index > -1 {
+			ops = append(ops, fmt.Sprintf(`{"op": "test", "path": "/secrets/%d/name", "value": "%s"}`, index, imagePullSecretName))
+			ops = append(ops, fmt.Sprintf(`{"op": "remove", "path": "/secrets/%d"}`, index))
+		}
+		index = slices.IndexFunc(serviceAccount.ImagePullSecrets, func(ref corev1.LocalObjectReference) bool {
+			return ref.Name == imagePullSecretName
+		})
+		if index > -1 {
+			ops = append(ops, fmt.Sprintf(`{"op": "test", "path": "/imagePullSecrets/%d/name", "value":"%s"}`, index, imagePullSecretName))
+			ops = append(ops, fmt.Sprintf(`{"op": "remove", "path": "/imagePullSecrets/%d"}`, index))
+		}
+	}
+	patch := "[" + strings.Join(ops, ",") + "]"
+	klog.V(1).InfoS("rolling back service account", "ns", serviceAccount.Namespace, "serviceAccount", serviceAccount.Name, "rollback", imagePullSecretName)
+	_, err = c.client.CoreV1().ServiceAccounts(serviceAccount.Namespace).Patch(ctx, serviceAccount.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
+	return err
+}
+
+func (c *serviceAccountRollbackController) Run(ctx context.Context, workers int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+	const name = "openshift.io/internal-image-registry-pull-secrets_service-account-rollback"
+	klog.InfoS("Starting controller", "name", name)
+	if !cache.WaitForNamedCacheSync(name, ctx.Done(), c.cacheSyncs...) {
+		return
+	}
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+	klog.InfoS("Started controller", "name", name)
+	<-ctx.Done()
+	klog.InfoS("Shutting down controller", "name", name)
+}
+
+func (c *serviceAccountRollbackController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *serviceAccountRollbackController) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+	err := c.sync(ctx, key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	c.queue.AddRateLimited(key)
+	return true
+}

--- a/pkg/serviceaccounts/controllers/rollback/service_account-rollback-controller_test.go
+++ b/pkg/serviceaccounts/controllers/rollback/service_account-rollback-controller_test.go
@@ -1,0 +1,285 @@
+package rollback
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func withAnnotation[T metav1.Object](k, v string) func(T) {
+	return func(s T) {
+		if s.GetAnnotations() == nil {
+			s.SetAnnotations(map[string]string{})
+		}
+		s.GetAnnotations()[k] = v
+	}
+}
+
+func TestServiceAccountRollbackControllerSync(t *testing.T) {
+
+	secret := func(opts ...func(*corev1.Secret)) *corev1.Secret {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "test_dockercfg_0"}}
+		for _, f := range opts {
+			f(s)
+		}
+		return s
+	}
+
+	withServiceAccountAnnotation := func(sa string) func(*corev1.Secret) {
+		return withAnnotation[*corev1.Secret]("openshift.io/internal-registry-auth-token.service-account", sa)
+	}
+
+	serviceAccount := func(opts ...func(*corev1.ServiceAccount)) *corev1.ServiceAccount {
+		s := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "test"}}
+		for _, f := range opts {
+			f(s)
+		}
+		return s
+	}
+
+	withImagePullSecretAnnotation := func(secret string) func(*corev1.ServiceAccount) {
+		return withAnnotation[*corev1.ServiceAccount]("openshift.io/internal-registry-pull-secret-ref", secret)
+	}
+
+	withImagePullSecrets := func(secrets ...string) func(*corev1.ServiceAccount) {
+		return func(sa *corev1.ServiceAccount) {
+			for _, s := range secrets {
+				sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{Name: s})
+			}
+		}
+	}
+
+	withSecrets := func(secrets ...string) func(*corev1.ServiceAccount) {
+		return func(sa *corev1.ServiceAccount) {
+			for _, s := range secrets {
+				sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: s})
+			}
+		}
+	}
+
+	testCases := []struct {
+		name                 string
+		secret               *corev1.Secret
+		serviceAccount       *corev1.ServiceAccount
+		cachedServiceAccount *corev1.ServiceAccount
+		expected             *corev1.ServiceAccount
+		expectErr            bool
+	}{
+		{
+			name: "existing future image pull secret refs in secrets imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret:   secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(),
+		},
+		{
+			name: "existing future image pull secret refs in secrets imagepullsecrets variation",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("a", "test_dockercfg_0"),
+				withSecrets("a", "test_dockercfg_0", "b"),
+			),
+			secret: secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(
+				withImagePullSecrets("a"),
+				withSecrets("a", "b"),
+			),
+		},
+		{
+			name: "existing future image pull secret refs in imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+			),
+			secret:   secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(),
+		},
+		{
+			name: "existing future image pull secret refs in secrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret:   secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(),
+		},
+		{
+			name: "existing future image pull secret refs in none",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+			),
+			secret:   secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(),
+		},
+		{
+			name: "deleted future image pull secret refs in secrets imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret:   nil,
+			expected: serviceAccount(),
+		},
+		{
+			name: "deleted future image pull secret refs in imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+			),
+			secret:   nil,
+			expected: serviceAccount(),
+		},
+		{
+			name: "deleted future image pull secret refs in secrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret:   nil,
+			expected: serviceAccount(),
+		},
+		{
+			name: "deleted future image pull secret refs in none",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+			),
+			secret:   nil,
+			expected: serviceAccount(),
+		},
+		{
+			name: "not future image pull secret refs in secrets imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret: secret(),
+			expected: serviceAccount(
+				withImagePullSecrets("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+		},
+		{
+			name: "existing future image pull secret refs in imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+			),
+			secret:   secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(),
+		},
+		{
+			name: "existing future image pull secret refs in secrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret:   secret(withServiceAccountAnnotation("test")),
+			expected: serviceAccount(),
+		},
+		{
+			name: "cache stale secrets imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_1", "test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			cachedServiceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+				withSecrets("test_dockercfg_1", "test_dockercfg_0"),
+			),
+			secret:    secret(withServiceAccountAnnotation("test")),
+			expectErr: true,
+		},
+		{
+			name: "cache stale imagepullsecrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_1", "test_dockercfg_0"),
+			),
+			cachedServiceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withImagePullSecrets("test_dockercfg_0"),
+			),
+			secret:    secret(withServiceAccountAnnotation("test")),
+			expectErr: true,
+		},
+		{
+			name: "cache stale secrets",
+			serviceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withSecrets("test_dockercfg_1", "test_dockercfg_0"),
+			),
+			cachedServiceAccount: serviceAccount(
+				withImagePullSecretAnnotation("test_dockercfg_0"),
+				withSecrets("test_dockercfg_0"),
+			),
+			secret:    secret(withServiceAccountAnnotation("test")),
+			expectErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cachedServiceAccount == nil {
+				tc.cachedServiceAccount = tc.serviceAccount
+			}
+			objects := []runtime.Object{tc.serviceAccount}
+			if tc.secret != nil {
+				objects = append(objects, tc.secret)
+			}
+			client := fake.NewSimpleClientset(objects...)
+			secretsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.secret != nil {
+				if err := secretsIndexer.Add(tc.secret); err != nil {
+					t.Fatal(err)
+				}
+			}
+			serviceAccountsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := serviceAccountsIndexer.Add(tc.cachedServiceAccount); err != nil {
+				t.Fatal(err)
+			}
+
+			controller := &serviceAccountRollbackController{
+				client:          client,
+				serviceAccounts: listers.NewServiceAccountLister(serviceAccountsIndexer),
+				secrets:         listers.NewSecretLister(secretsIndexer),
+			}
+
+			err := controller.sync(ctx, tc.serviceAccount.Namespace+"/"+tc.serviceAccount.Name)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatal(err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatal("expected error")
+			}
+
+			actual, err := client.CoreV1().ServiceAccounts(tc.serviceAccount.Namespace).Get(ctx, tc.serviceAccount.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !equality.Semantic.DeepEqual(tc.expected, actual) {
+				t.Fatal(cmp.Diff(tc.expected, actual))
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
* Revert: https://github.com/openshift/openshift-controller-manager/pull/301
* Fix: https://issues.redhat.com/browse/OCPBUGS-33088