### PR TITLE
OCPBUGS-12699: Whitelists lower-case proxy envs to pod proxydefaults

### DIFF
--- a/pkg/build/buildutil/util_test.go
+++ b/pkg/build/buildutil/util_test.go
@@ -171,6 +171,47 @@ func TestMergeEnvWithoutDuplicates(t *testing.T) {
 				{Name: "LANG", Value: "en_US.utf8"},
 			},
 		},
+		{
+			name:      "use proxy env variables all upper-case",
+			whitelist: buildv1.WhitelistEnvVarNames,
+			input: []corev1.EnvVar{
+				// stripped by whitelist
+				{Name: "foo", Value: "bar"},
+				// stripped by whitelist
+				{Name: "input", Value: "inputVal"},
+				{Name: "HTTP_PROXY", Value: "http://username:password@127.0.0.1:80"},
+				{Name: "HTTPS_PROXY", Value: "https://username:password@127.0.0.1:443"},
+				{Name: "NO_PROXY", Value: "localdomain.com"},
+			},
+			currentOutput: []corev1.EnvVar{
+				{Name: "foo", Value: "test"},
+			},
+			expectedOutput: []corev1.EnvVar{
+				{Name: "foo", Value: "test"},
+				{Name: "HTTP_PROXY", Value: "http://username:password@127.0.0.1:80"},
+				{Name: "HTTPS_PROXY", Value: "https://username:password@127.0.0.1:443"},
+				{Name: "NO_PROXY", Value: "localdomain.com"},
+			},
+		},
+		{
+			name:      "use proxy env variables all lower-case",
+			whitelist: buildv1.WhitelistEnvVarNames,
+			input: []corev1.EnvVar{
+				// stripped by whitelist
+				{Name: "foo", Value: "bar"},
+				// stripped by whitelist
+				{Name: "input", Value: "inputVal"},
+				{Name: "http_proxy", Value: "http://username:password@127.0.0.1:80"},
+				{Name: "https_proxy", Value: "https://username:password@127.0.0.1:443"},
+				{Name: "no_proxy", Value: "localdomain.com"},
+			},
+			currentOutput: []corev1.EnvVar{},
+			expectedOutput: []corev1.EnvVar{
+				{Name: "http_proxy", Value: "http://username:password@127.0.0.1:80"},
+				{Name: "https_proxy", Value: "https://username:password@127.0.0.1:443"},
+				{Name: "no_proxy", Value: "localdomain.com"},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/build/controller/build/defaults/defaults.go
+++ b/pkg/build/controller/build/defaults/defaults.go
@@ -96,8 +96,11 @@ func (b BuildDefaults) applyPodProxyDefaults(pod *corev1.Pod, isCustomBuild bool
 		// total control over the env+logic in a custom build pod anyway.
 		externalEnv := []corev1.EnvVar{}
 		externalEnv = append(externalEnv, corev1.EnvVar{Name: "HTTP_PROXY", Value: b.DefaultProxy.HTTPProxy})
+		externalEnv = append(externalEnv, corev1.EnvVar{Name: "http_proxy", Value: b.DefaultProxy.HTTPProxy})
 		externalEnv = append(externalEnv, corev1.EnvVar{Name: "HTTPS_PROXY", Value: b.DefaultProxy.HTTPSProxy})
+		externalEnv = append(externalEnv, corev1.EnvVar{Name: "https_proxy", Value: b.DefaultProxy.HTTPSProxy})
 		externalEnv = append(externalEnv, corev1.EnvVar{Name: "NO_PROXY", Value: b.DefaultProxy.NoProxy})
+		externalEnv = append(externalEnv, corev1.EnvVar{Name: "no_proxy", Value: b.DefaultProxy.NoProxy})
 
 		if isCustomBuild {
 			buildutil.MergeEnvWithoutDuplicates(externalEnv, &c.Env, false, []string{})

--- a/pkg/build/controller/build/defaults/defaults_test.go
+++ b/pkg/build/controller/build/defaults/defaults_test.go
@@ -163,35 +163,24 @@ func TestGlobalProxyDefaults(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	httpProxyFound, httpsProxyFound, noProxyFound := false, false, false
+	proxyEnvs := map[string]string{
+		"HTTP_PROXY": "http", "http_proxy": "http", "HTTPS_PROXY": "https", "https_proxy": "https", "NO_PROXY": "no", "no_proxy": "no",
+	}
+	proxyFound := map[string]bool{
+		"HTTP_PROXY": false, "http_proxy": false, "HTTPS_PROXY": false, "https_proxy": false, "NO_PROXY": false, "no_proxy": false,
+	}
 	for _, ev := range pod.Spec.Containers[0].Env {
-		if ev.Name == "HTTP_PROXY" {
-			if ev.Value != "http" {
+		if val, found := proxyEnvs[ev.Name]; found {
+			if ev.Value != val {
 				t.Errorf("unexpected value %s", ev.Value)
 			}
-			httpProxyFound = true
-		}
-		if ev.Name == "HTTPS_PROXY" {
-			if ev.Value != "https" {
-				t.Errorf("unexpected value %s", ev.Value)
-			}
-			httpsProxyFound = true
-		}
-		if ev.Name == "NO_PROXY" {
-			if ev.Value != "no" {
-				t.Errorf("unexpected value %s", ev.Value)
-			}
-			noProxyFound = true
+			proxyFound[ev.Name] = true
 		}
 	}
-	if !httpProxyFound {
-		t.Errorf("HTTP_PROXY not found")
-	}
-	if !httpsProxyFound {
-		t.Errorf("HTTPS_PROXY not found")
-	}
-	if !noProxyFound {
-		t.Errorf("NO_PROXY not found")
+	for k, v := range proxyFound {
+		if !v {
+			t.Errorf("%s not found", k)
+		}
 	}
 
 	// source builds should not have the defaulted env vars applied to the build
@@ -199,17 +188,10 @@ func TestGlobalProxyDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	env := buildutil.GetBuildEnv(build)
 	for _, ev := range env {
-		if ev.Name == "HTTP_PROXY" {
-			t.Errorf("HTTP_PROXY was found, but should not have been")
-		}
-		if ev.Name == "HTTPS_PROXY" {
-			t.Errorf("HTTPS_PROXY was found, but should not have been")
-		}
-		if ev.Name == "NO_PROXY" {
-			t.Errorf("NO_PROXY was found, but should not have been")
+		if _, found := proxyEnvs[ev.Name]; found {
+			t.Errorf("%s was found, but should not have been", ev.Name)
 		}
 	}
 
@@ -220,35 +202,21 @@ func TestGlobalProxyDefaults(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	httpProxyFound, httpsProxyFound, noProxyFound = false, false, false
+	proxyFound = map[string]bool{
+		"HTTP_PROXY": false, "http_proxy": false, "HTTPS_PROXY": false, "https_proxy": false, "NO_PROXY": false, "no_proxy": false,
+	}
 	for _, ev := range pod.Spec.Containers[0].Env {
-		if ev.Name == "HTTP_PROXY" {
-			if ev.Value != "http" {
+		if val, found := proxyEnvs[ev.Name]; found {
+			if ev.Value != val {
 				t.Errorf("unexpected value %s", ev.Value)
 			}
-			httpProxyFound = true
-		}
-		if ev.Name == "HTTPS_PROXY" {
-			if ev.Value != "https" {
-				t.Errorf("unexpected value %s", ev.Value)
-			}
-			httpsProxyFound = true
-		}
-		if ev.Name == "NO_PROXY" {
-			if ev.Value != "no" {
-				t.Errorf("unexpected value %s", ev.Value)
-			}
-			noProxyFound = true
+			proxyFound[ev.Name] = true
 		}
 	}
-	if !httpProxyFound {
-		t.Errorf("HTTP_PROXY not found")
-	}
-	if !httpsProxyFound {
-		t.Errorf("HTTPS_PROXY not found")
-	}
-	if !noProxyFound {
-		t.Errorf("NO_PROXY not found")
+	for k, v := range proxyFound {
+		if !v {
+			t.Errorf("%s not found", k)
+		}
 	}
 
 	// docker builds should not have the defaulted env vars applied to the build
@@ -259,14 +227,8 @@ func TestGlobalProxyDefaults(t *testing.T) {
 
 	env = buildutil.GetBuildEnv(build)
 	for _, ev := range env {
-		if ev.Name == "HTTP_PROXY" {
-			t.Errorf("HTTP_PROXY was found, but should not have been")
-		}
-		if ev.Name == "HTTPS_PROXY" {
-			t.Errorf("HTTPS_PROXY was found, but should not have been")
-		}
-		if ev.Name == "NO_PROXY" {
-			t.Errorf("NO_PROXY was found, but should not have been")
+		if _, found := proxyEnvs[ev.Name]; found {
+			t.Errorf("%s was found, but should not have been", ev.Name)
 		}
 	}
 
@@ -277,35 +239,21 @@ func TestGlobalProxyDefaults(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	httpProxyFound, httpsProxyFound, noProxyFound = false, false, false
+	proxyFound = map[string]bool{
+		"HTTP_PROXY": false, "http_proxy": false, "HTTPS_PROXY": false, "https_proxy": false, "NO_PROXY": false, "no_proxy": false,
+	}
 	for _, ev := range pod.Spec.Containers[0].Env {
-		if ev.Name == "HTTP_PROXY" {
-			if ev.Value != "http" {
+		if val, found := proxyEnvs[ev.Name]; found {
+			if ev.Value != val {
 				t.Errorf("unexpected value %s", ev.Value)
 			}
-			httpProxyFound = true
-		}
-		if ev.Name == "HTTPS_PROXY" {
-			if ev.Value != "https" {
-				t.Errorf("unexpected value %s", ev.Value)
-			}
-			httpsProxyFound = true
-		}
-		if ev.Name == "NO_PROXY" {
-			if ev.Value != "no" {
-				t.Errorf("unexpected value %s", ev.Value)
-			}
-			noProxyFound = true
+			proxyFound[ev.Name] = true
 		}
 	}
-	if !httpProxyFound {
-		t.Errorf("HTTP_PROXY not found")
-	}
-	if !httpsProxyFound {
-		t.Errorf("HTTPS_PROXY not found")
-	}
-	if !noProxyFound {
-		t.Errorf("NO_PROXY not found")
+	for k, v := range proxyFound {
+		if !v {
+			t.Errorf("%s not found", k)
+		}
 	}
 
 	// custom builds should not have the defaulted env vars applied to the build
@@ -316,14 +264,8 @@ func TestGlobalProxyDefaults(t *testing.T) {
 
 	env = buildutil.GetBuildEnv(build)
 	for _, ev := range env {
-		if ev.Name == "HTTP_PROXY" {
-			t.Errorf("HTTP_PROXY was found, but should not have been")
-		}
-		if ev.Name == "HTTPS_PROXY" {
-			t.Errorf("HTTPS_PROXY was found, but should not have been")
-		}
-		if ev.Name == "NO_PROXY" {
-			t.Errorf("NO_PROXY was found, but should not have been")
+		if _, found := proxyEnvs[ev.Name]; found {
+			t.Errorf("%s was found, but should not have been", ev.Name)
 		}
 	}
 }


### PR DESCRIPTION
With https://github.com/openshift/api/pull/1659 additional env variables were whitelisted (proxy vars in lowercase). This commit adds testcases for all the whitelisted proxy env vars.