### PR TITLE
OCPBUGS-35731: Race condition when deleting ServiceAccount

### DIFF
--- a/pkg/internalregistry/controllers/image_pull_secret_controller.go
+++ b/pkg/internalregistry/controllers/image_pull_secret_controller.go
@@ -147,6 +147,9 @@ func (c *imagePullSecretController) sync(ctx context.Context, key string) (error
 				return err, 0
 			}
 			patch.WithAnnotations(map[string]string{InternalRegistryAuthTokenTypeAnnotation: AuthTokenTypeBound})
+			// add the UID to the patch to ensure we don't re-create the secret if it no longer exists.
+			// the service account controller is responsible for re-creating the initial secret.
+			patch.WithUID(secret.UID)
 			_, err = c.client.CoreV1().Secrets(secret.Namespace).Apply(ctx, patch, metav1.ApplyOptions{Force: true, FieldManager: imagePullSecretControllerFieldManager})
 			if err != nil {
 				return err, 0
@@ -184,7 +187,10 @@ func (c *imagePullSecretController) sync(ctx context.Context, key string) (error
 			InternalRegistryAuthTokenTypeAnnotation: AuthTokenTypeBound,
 		}).
 		WithType(corev1.SecretTypeDockercfg).
-		WithData(map[string][]byte{corev1.DockerConfigKey: data})
+		WithData(map[string][]byte{corev1.DockerConfigKey: data}).
+		// add the UID to the patch to ensure we don't re-create the secret if it no longer exists.
+		// the service account controller is responsible for re-creating the initial secret.
+		WithUID(secret.UID)
 	_, err = c.client.CoreV1().Secrets(secret.Namespace).Apply(ctx, patch, metav1.ApplyOptions{Force: true, FieldManager: imagePullSecretControllerFieldManager})
 
 	if err != nil {

--- a/pkg/internalregistry/controllers/legacy_token_secret_controller.go
+++ b/pkg/internalregistry/controllers/legacy_token_secret_controller.go
@@ -72,12 +72,6 @@ func NewLegacyTokenSecretController(client kubernetes.Interface, secrets informe
 					c.queue.Add(key)
 				}
 			},
-			DeleteFunc: func(obj any) {
-				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				if err == nil {
-					c.queue.Add(key)
-				}
-			},
 		},
 	})
 	return c

--- a/pkg/internalregistry/controllers/service_account_controller.go
+++ b/pkg/internalregistry/controllers/service_account_controller.go
@@ -68,12 +68,6 @@ func NewServiceAccountController(kubeclient kubernetes.Interface, serviceAccount
 				c.queue.Add(key)
 			}
 		},
-		DeleteFunc: func(obj any) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			if err == nil {
-				c.queue.Add(key)
-			}
-		},
 	})
 
 	secrets.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -146,6 +140,8 @@ func (c *serviceAccountController) sync(ctx context.Context, key string) error {
 			return err
 		}
 		patch.WithAnnotations(map[string]string{InternalRegistryImagePullSecretRefKey: secretName})
+		// add the UID to the patch to ensure we don't re-create the service account if it no longer exists
+		patch.WithUID(serviceAccount.UID)
 		// we apply this now to ensure the secret name stays stable in case a error occurs while reconciling
 		serviceAccount, err = c.client.CoreV1().ServiceAccounts(ns).Apply(ctx, patch, metav1.ApplyOptions{Force: true, FieldManager: serviceAccountControllerFieldManager})
 		if err != nil {
@@ -228,6 +224,9 @@ func (c *serviceAccountController) sync(ctx context.Context, key string) error {
 	} else {
 		patch.ImagePullSecrets = slices.DeleteFunc(patch.ImagePullSecrets, func(ref applycorev1.LocalObjectReferenceApplyConfiguration) bool { return *ref.Name == secretName })
 	}
+
+	// add the UID to the patch to ensure we don't re-create the service account if it no longer exists
+	patch.WithUID(serviceAccount.UID)
 
 	serviceAccount, err = c.client.CoreV1().ServiceAccounts(ns).Apply(ctx, patch, metav1.ApplyOptions{Force: true, FieldManager: serviceAccountControllerFieldManager})
 	if err != nil {


### PR DESCRIPTION
- Altered the apply API calls to prevent the re-creation of a service account deleted between the beginning of a control loop and the API call. 
- Hardened apply API calls for the manage image pull secrets to prevent accidental re-creation.
- improved handling of deletion events 