### PR TITLE
OCPBUGS-30704: replaces deprecated square/go-jose wtih go-jose/go-jose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,3 +217,8 @@ replace (
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.1
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.1
 )
+
+replace (
+	gopkg.in/go-jose/go-jose.v2 v2.6.0-unstable => github.com/go-jose/go-jose v2.6.3+incompatible
+	gopkg.in/square/go-jose.v2 v2.6.0-unstable => github.com/go-jose/go-jose v2.6.3+incompatible
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2021,3 +2021,5 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.29.1
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.1
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.1
+# gopkg.in/go-jose/go-jose.v2 v2.6.0-unstable => github.com/go-jose/go-jose v2.6.3+incompatible
+# gopkg.in/square/go-jose.v2 v2.6.0-unstable => github.com/go-jose/go-jose v2.6.3+incompatible


### PR DESCRIPTION
This commit replaces all the references of [github.com/square/go-jose](https://github.com/square/go-jose) to [github.com/go-jose/go-jose@v2](https://github.com/go-jose/go-jose).