### PR TITLE
OCPBUGS-42106: Continuous pull-secret updates / slow initialization on build01 (test platform infrastructure)

### DIFF
--- a/pkg/internalregistry/controllers/registry_urls_observation_controller.go
+++ b/pkg/internalregistry/controllers/registry_urls_observation_controller.go
@@ -84,6 +84,7 @@ func (c *registryURLObservation) sync(ctx context.Context, key string) error {
 		urls = append(urls, urlsForInternalRegistryService(c.services, location)...)
 	}
 	slices.Sort(urls)
+	urls = slices.Compact(urls)
 	select {
 	case c.ch <- urls:
 	case <-ctx.Done():


### PR DESCRIPTION
A duplicate in the list of registry URLs will cause the controller to think that all image pull secrets needs to be refreshed. This PR de-duplicates the list of registry URLs to prevent that.