### PR TITLE
OCPBUGS-32867: replaces deprecated square/go-jose with go-jose/go-jose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,3 +183,8 @@ replace (
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.1
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.1
 )
+
+replace (
+	github.com/go-jose/go-jose.v2 => github.com/go-jose/go-jose v2.6.3+incompatible
+	gopkg.in/square/go-jose.v2 v2.6.0 => github.com/go-jose/go-jose v2.6.0+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/go-jose/go-jose v2.6.0+incompatible h1:kY44+vlF5pTQ5yZ2TWIhzr48bA01bizxUfvt5Y0Z4nQ=
+github.com/go-jose/go-jose v2.6.0+incompatible/go.mod h1:coBhWG9DQz8V/JlBMg3LkUGnarUaxjQlWQUUv9Cv7tw=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -1976,7 +1978,6 @@ gopkg.in/ini.v1 v1.63.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/square/go-jose.v2 v2.2.2 h1:orlkJ3myw8CN1nVQHBFfloD+L3egixIa4FvUP6RosSA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/vendor/gopkg.in/square/go-jose.v2/.gitignore
+++ b/vendor/gopkg.in/square/go-jose.v2/.gitignore
@@ -5,3 +5,4 @@
 *.pem
 *.cov
 jose-util/jose-util
+jose-util.t.err

--- a/vendor/gopkg.in/square/go-jose.v2/.travis.yml
+++ b/vendor/gopkg.in/square/go-jose.v2/.travis.yml
@@ -8,12 +8,9 @@ matrix:
     - go: tip
 
 go:
-- '1.5.x'
-- '1.6.x'
-- '1.7.x'
-- '1.8.x'
-- '1.9.x'
-- '1.10.x'
+- '1.14.x'
+- '1.15.x'
+- tip
 
 go_import_path: gopkg.in/square/go-jose.v2
 
@@ -29,6 +26,8 @@ before_install:
 - go get github.com/wadey/gocovmerge
 - go get github.com/mattn/goveralls
 - go get github.com/stretchr/testify/assert
+- go get github.com/stretchr/testify/require
+- go get github.com/google/go-cmp/cmp
 - go get golang.org/x/tools/cmd/cover || true
 - go get code.google.com/p/go.tools/cmd/cover || true
 - pip install cram --user
@@ -38,10 +37,9 @@ script:
 - go test ./cipher -v -covermode=count -coverprofile=cipher/profile.cov
 - go test ./jwt -v -covermode=count -coverprofile=jwt/profile.cov
 - go test ./json -v # no coverage for forked encoding/json package
-- cd jose-util && go build && PATH=$PWD:$PATH cram -v jose-util.t
+- cd jose-util && go build && PATH=$PWD:$PATH cram -v jose-util.t # cram tests jose-util
 - cd ..
 
 after_success:
 - gocovmerge *.cov */*.cov > merged.coverprofile
 - $HOME/gopath/bin/goveralls -coverprofile merged.coverprofile -service=travis-ci
-

--- a/vendor/gopkg.in/square/go-jose.v2/asymmetric.go
+++ b/vendor/gopkg.in/square/go-jose.v2/asymmetric.go
@@ -29,7 +29,7 @@ import (
 	"math/big"
 
 	"golang.org/x/crypto/ed25519"
-	"gopkg.in/square/go-jose.v2/cipher"
+	josecipher "gopkg.in/square/go-jose.v2/cipher"
 	"gopkg.in/square/go-jose.v2/json"
 )
 
@@ -288,7 +288,7 @@ func (ctx rsaDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm
 		out, err = rsa.SignPKCS1v15(RandReader, ctx.privateKey, hash, hashed)
 	case PS256, PS384, PS512:
 		out, err = rsa.SignPSS(RandReader, ctx.privateKey, hash, hashed, &rsa.PSSOptions{
-			SaltLength: rsa.PSSSaltLengthAuto,
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
 		})
 	}
 

--- a/vendor/gopkg.in/square/go-jose.v2/cipher/cbc_hmac.go
+++ b/vendor/gopkg.in/square/go-jose.v2/cipher/cbc_hmac.go
@@ -150,7 +150,7 @@ func (ctx *cbcAEAD) computeAuthTag(aad, nonce, ciphertext []byte) []byte {
 	return hmac.Sum(nil)[:ctx.authtagBytes]
 }
 
-// resize ensures the the given slice has a capacity of at least n bytes.
+// resize ensures that the given slice has a capacity of at least n bytes.
 // If the capacity of the slice is less than n, a new slice is allocated
 // and the existing data will be copied.
 func resize(in []byte, n uint64) (head, tail []byte) {

--- a/vendor/gopkg.in/square/go-jose.v2/crypter.go
+++ b/vendor/gopkg.in/square/go-jose.v2/crypter.go
@@ -141,6 +141,8 @@ func NewEncrypter(enc ContentEncryption, rcpt Recipient, opts *EncrypterOptions)
 		keyID, rawKey = encryptionKey.KeyID, encryptionKey.Key
 	case *JSONWebKey:
 		keyID, rawKey = encryptionKey.KeyID, encryptionKey.Key
+	case OpaqueKeyEncrypter:
+		keyID, rawKey = encryptionKey.KeyID(), encryptionKey
 	default:
 		rawKey = encryptionKey
 	}
@@ -214,6 +216,7 @@ func NewMultiEncrypter(enc ContentEncryption, rcpts []Recipient, opts *Encrypter
 
 	if opts != nil {
 		encrypter.compressionAlg = opts.Compression
+		encrypter.extraHeaders = opts.ExtraHeaders
 	}
 
 	for _, recipient := range rcpts {
@@ -267,9 +270,11 @@ func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKey
 		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
 		recipient.keyID = encryptionKey.KeyID
 		return recipient, err
-	default:
-		return recipientKeyInfo{}, ErrUnsupportedKeyType
 	}
+	if encrypter, ok := encryptionKey.(OpaqueKeyEncrypter); ok {
+		return newOpaqueKeyEncrypter(alg, encrypter)
+	}
+	return recipientKeyInfo{}, ErrUnsupportedKeyType
 }
 
 // newDecrypter creates an appropriate decrypter based on the key type
@@ -295,9 +300,11 @@ func newDecrypter(decryptionKey interface{}) (keyDecrypter, error) {
 		return newDecrypter(decryptionKey.Key)
 	case *JSONWebKey:
 		return newDecrypter(decryptionKey.Key)
-	default:
-		return nil, ErrUnsupportedKeyType
 	}
+	if okd, ok := decryptionKey.(OpaqueKeyDecrypter); ok {
+		return &opaqueKeyDecrypter{decrypter: okd}, nil
+	}
+	return nil, ErrUnsupportedKeyType
 }
 
 // Implementation of encrypt method producing a JWE object.

--- a/vendor/gopkg.in/square/go-jose.v2/encoding.go
+++ b/vendor/gopkg.in/square/go-jose.v2/encoding.go
@@ -23,12 +23,11 @@ import (
 	"encoding/binary"
 	"io"
 	"math/big"
-	"regexp"
+	"strings"
+	"unicode"
 
 	"gopkg.in/square/go-jose.v2/json"
 )
-
-var stripWhitespaceRegex = regexp.MustCompile("\\s")
 
 // Helper function to serialize known-good objects.
 // Precondition: value is not a nil pointer.
@@ -56,7 +55,14 @@ func mustSerializeJSON(value interface{}) []byte {
 
 // Strip all newlines and whitespace
 func stripWhitespace(data string) string {
-	return stripWhitespaceRegex.ReplaceAllString(data, "")
+	buf := strings.Builder{}
+	buf.Grow(len(data))
+	for _, r := range data {
+		if !unicode.IsSpace(r) {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
 }
 
 // Perform compression based on algorithm

--- a/vendor/gopkg.in/square/go-jose.v2/json/stream.go
+++ b/vendor/gopkg.in/square/go-jose.v2/json/stream.go
@@ -31,9 +31,14 @@ func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{r: r}
 }
 
+// Deprecated: Use `SetNumberType` instead
 // UseNumber causes the Decoder to unmarshal a number into an interface{} as a
 // Number instead of as a float64.
-func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
+func (dec *Decoder) UseNumber() { dec.d.numberType = UnmarshalJSONNumber }
+
+// SetNumberType causes the Decoder to unmarshal a number into an interface{} as a
+// Number, float64 or int64 depending on `t` enum value.
+func (dec *Decoder) SetNumberType(t NumberUnmarshalType) { dec.d.numberType = t }
 
 // Decode reads the next JSON-encoded value from its
 // input and stores it in the value pointed to by v.

--- a/vendor/gopkg.in/square/go-jose.v2/jwk.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwk.go
@@ -17,15 +17,20 @@
 package jose
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -57,16 +62,31 @@ type rawJSONWebKey struct {
 	Dq *byteBuffer `json:"dq,omitempty"`
 	Qi *byteBuffer `json:"qi,omitempty"`
 	// Certificates
-	X5c []string `json:"x5c,omitempty"`
+	X5c       []string `json:"x5c,omitempty"`
+	X5u       *url.URL `json:"x5u,omitempty"`
+	X5tSHA1   string   `json:"x5t,omitempty"`
+	X5tSHA256 string   `json:"x5t#S256,omitempty"`
 }
 
 // JSONWebKey represents a public or private key in JWK format.
 type JSONWebKey struct {
-	Key          interface{}
+	// Cryptographic key, can be a symmetric or asymmetric key.
+	Key interface{}
+	// Key identifier, parsed from `kid` header.
+	KeyID string
+	// Key algorithm, parsed from `alg` header.
+	Algorithm string
+	// Key use, parsed from `use` header.
+	Use string
+
+	// X.509 certificate chain, parsed from `x5c` header.
 	Certificates []*x509.Certificate
-	KeyID        string
-	Algorithm    string
-	Use          string
+	// X.509 certificate URL, parsed from `x5u` header.
+	CertificatesURL *url.URL
+	// X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.
+	CertificateThumbprintSHA1 []byte
+	// X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.
+	CertificateThumbprintSHA256 []byte
 }
 
 // MarshalJSON serializes the given key to its JSON representation.
@@ -105,6 +125,39 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 		raw.X5c = append(raw.X5c, base64.StdEncoding.EncodeToString(cert.Raw))
 	}
 
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 {
+		if x5tSHA1Len != sha1.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-1 thumbprint (must be %d bytes, not %d)", sha1.Size, x5tSHA1Len)
+		}
+		raw.X5tSHA1 = base64.RawURLEncoding.EncodeToString(k.CertificateThumbprintSHA1)
+	}
+	if x5tSHA256Len > 0 {
+		if x5tSHA256Len != sha256.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-256 thumbprint (must be %d bytes, not %d)", sha256.Size, x5tSHA256Len)
+		}
+		raw.X5tSHA256 = base64.RawURLEncoding.EncodeToString(k.CertificateThumbprintSHA256)
+	}
+
+	// If cert chain is attached (as opposed to being behind a URL), check the
+	// keys thumbprints to make sure they match what is expected. This is to
+	// ensure we don't accidentally produce a JWK with semantically inconsistent
+	// data in the headers.
+	if len(k.Certificates) > 0 {
+		expectedSHA1 := sha1.Sum(k.Certificates[0].Raw)
+		expectedSHA256 := sha256.Sum256(k.Certificates[0].Raw)
+
+		if len(k.CertificateThumbprintSHA1) > 0 && !bytes.Equal(k.CertificateThumbprintSHA1, expectedSHA1[:]) {
+			return nil, errors.New("square/go-jose: invalid SHA-1 thumbprint, does not match cert chain")
+		}
+		if len(k.CertificateThumbprintSHA256) > 0 && !bytes.Equal(k.CertificateThumbprintSHA256, expectedSHA256[:]) {
+			return nil, errors.New("square/go-jose: invalid or SHA-256 thumbprint, does not match cert chain")
+		}
+	}
+
+	raw.X5u = k.CertificatesURL
+
 	return json.Marshal(raw)
 }
 
@@ -116,28 +169,61 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		return err
 	}
 
+	certs, err := parseCertificateChain(raw.X5c)
+	if err != nil {
+		return fmt.Errorf("square/go-jose: failed to unmarshal x5c field: %s", err)
+	}
+
 	var key interface{}
+	var certPub interface{}
+	var keyPub interface{}
+
+	if len(certs) > 0 {
+		// We need to check that leaf public key matches the key embedded in this
+		// JWK, as required by the standard (see RFC 7517, Section 4.7). Otherwise
+		// the JWK parsed could be semantically invalid. Technically, should also
+		// check key usage fields and other extensions on the cert here, but the
+		// standard doesn't exactly explain how they're supposed to map from the
+		// JWK representation to the X.509 extensions.
+		certPub = certs[0].PublicKey
+	}
+
 	switch raw.Kty {
 	case "EC":
 		if raw.D != nil {
 			key, err = raw.ecPrivateKey()
+			if err == nil {
+				keyPub = key.(*ecdsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.ecPublicKey()
+			keyPub = key
 		}
 	case "RSA":
 		if raw.D != nil {
 			key, err = raw.rsaPrivateKey()
+			if err == nil {
+				keyPub = key.(*rsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.rsaPublicKey()
+			keyPub = key
 		}
 	case "oct":
+		if certPub != nil {
+			return errors.New("square/go-jose: invalid JWK, found 'oct' (symmetric) key with cert chain")
+		}
 		key, err = raw.symmetricKey()
 	case "OKP":
 		if raw.Crv == "Ed25519" && raw.X != nil {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
+				if err == nil {
+					keyPub = key.(ed25519.PrivateKey).Public()
+				}
 			} else {
 				key, err = raw.edPublicKey()
+				keyPub = key
 			}
 		} else {
 			err = fmt.Errorf("square/go-jose: unknown curve %s'", raw.Crv)
@@ -146,12 +232,78 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		err = fmt.Errorf("square/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
-	if err == nil {
-		*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use}
+	if err != nil {
+		return
+	}
 
-		k.Certificates, err = parseCertificateChain(raw.X5c)
+	if certPub != nil && keyPub != nil {
+		if !reflect.DeepEqual(certPub, keyPub) {
+			return errors.New("square/go-jose: invalid JWK, public keys in key and x5c fields do not match")
+		}
+	}
+
+	*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use, Certificates: certs}
+
+	k.CertificatesURL = raw.X5u
+
+	// x5t parameters are base64url-encoded SHA thumbprints
+	// See RFC 7517, Section 4.8, https://tools.ietf.org/html/rfc7517#section-4.8
+	x5tSHA1bytes, err := base64.RawURLEncoding.DecodeString(raw.X5tSHA1)
+	if err != nil {
+		return errors.New("square/go-jose: invalid JWK, x5t header has invalid encoding")
+	}
+
+	// RFC 7517, Section 4.8 is ambiguous as to whether the digest output should be byte or hex,
+	// for this reason, after base64 decoding, if the size is sha1.Size it's likely that the value is a byte encoded
+	// checksum so we skip this. Otherwise if the checksum was hex encoded we expect a 40 byte sized array so we'll
+	// try to hex decode it. When Marshalling this value we'll always use a base64 encoded version of byte format checksum.
+	if len(x5tSHA1bytes) == 2*sha1.Size {
+		hx, err := hex.DecodeString(string(x5tSHA1bytes))
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal x5c field: %s", err)
+			return fmt.Errorf("square/go-jose: invalid JWK, unable to hex decode x5t: %v", err)
+
+		}
+		x5tSHA1bytes = hx
+	}
+
+	k.CertificateThumbprintSHA1 = x5tSHA1bytes
+
+	x5tSHA256bytes, err := base64.RawURLEncoding.DecodeString(raw.X5tSHA256)
+	if err != nil {
+		return errors.New("square/go-jose: invalid JWK, x5t#S256 header has invalid encoding")
+	}
+
+	if len(x5tSHA256bytes) == 2*sha256.Size {
+		hx256, err := hex.DecodeString(string(x5tSHA256bytes))
+		if err != nil {
+			return fmt.Errorf("square/go-jose: invalid JWK, unable to hex decode x5t#S256: %v", err)
+		}
+		x5tSHA256bytes = hx256
+	}
+
+	k.CertificateThumbprintSHA256 = x5tSHA256bytes
+
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 && x5tSHA1Len != sha1.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t header is of incorrect size")
+	}
+	if x5tSHA256Len > 0 && x5tSHA256Len != sha256.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t#S256 header is of incorrect size")
+	}
+
+	// If certificate chain *and* thumbprints are set, verify correctness.
+	if len(k.Certificates) > 0 {
+		leaf := k.Certificates[0]
+		sha1sum := sha1.Sum(leaf.Raw)
+		sha256sum := sha256.Sum256(leaf.Raw)
+
+		if len(k.CertificateThumbprintSHA1) > 0 && !bytes.Equal(sha1sum[:], k.CertificateThumbprintSHA1) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t value")
+		}
+
+		if len(k.CertificateThumbprintSHA256) > 0 && !bytes.Equal(sha256sum[:], k.CertificateThumbprintSHA256) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t#S256 value")
 		}
 	}
 
@@ -180,7 +332,7 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
 const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
-const edThumbprintTemplate = `{"crv":"%s","kty":"OKP",x":"%s"}`
+const edThumbprintTemplate = `{"crv":"%s","kty":"OKP","x":"%s"}`
 
 func ecThumbprintInput(curve elliptic.Curve, x, y *big.Int) (string, error) {
 	coordLength := curveSize(curve)
@@ -230,7 +382,7 @@ func (k *JSONWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	case *rsa.PrivateKey:
 		input, err = rsaThumbprintInput(key.N, key.E)
 	case ed25519.PrivateKey:
-		input, err = edThumbprintInput(ed25519.PublicKey(key[0:32]))
+		input, err = edThumbprintInput(ed25519.PublicKey(key[32:]))
 	default:
 		return nil, fmt.Errorf("square/go-jose: unknown key type '%s'", reflect.TypeOf(key))
 	}
@@ -254,7 +406,7 @@ func (k *JSONWebKey) IsPublic() bool {
 	}
 }
 
-// Public creates JSONWebKey with corresponding publik key if JWK represents asymmetric private key.
+// Public creates JSONWebKey with corresponding public key if JWK represents asymmetric private key.
 func (k *JSONWebKey) Public() JSONWebKey {
 	if k.IsPublic() {
 		return *k
@@ -357,11 +509,11 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 	// the curve specified in the "crv" parameter.
 	// https://tools.ietf.org/html/rfc7518#section-6.2.1.2
 	if curveSize(curve) != len(key.X.data) {
-		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for x")
+		return nil, fmt.Errorf("square/go-jose: invalid EC public key, wrong length for x")
 	}
 
 	if curveSize(curve) != len(key.Y.data) {
-		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for y")
+		return nil, fmt.Errorf("square/go-jose: invalid EC public key, wrong length for y")
 	}
 
 	x := key.X.bigInt()
@@ -421,8 +573,8 @@ func (key rawJSONWebKey) edPrivateKey() (ed25519.PrivateKey, error) {
 	}
 
 	privateKey := make([]byte, ed25519.PrivateKeySize)
-	copy(privateKey[0:32], key.X.bytes())
-	copy(privateKey[32:], key.D.bytes())
+	copy(privateKey[0:32], key.D.bytes())
+	copy(privateKey[32:], key.X.bytes())
 	rv := ed25519.PrivateKey(privateKey)
 	return rv, nil
 }
@@ -483,9 +635,9 @@ func (key rawJSONWebKey) rsaPrivateKey() (*rsa.PrivateKey, error) {
 }
 
 func fromEdPrivateKey(ed ed25519.PrivateKey) (*rawJSONWebKey, error) {
-	raw := fromEdPublicKey(ed25519.PublicKey(ed[0:32]))
+	raw := fromEdPublicKey(ed25519.PublicKey(ed[32:]))
 
-	raw.D = newBuffer(ed[32:])
+	raw.D = newBuffer(ed[0:32])
 	return raw, nil
 }
 

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/builder.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/builder.go
@@ -143,7 +143,7 @@ func normalize(i interface{}) (map[string]interface{}, error) {
 	}
 
 	d := json.NewDecoder(bytes.NewReader(raw))
-	d.UseNumber()
+	d.SetNumberType(json.UnmarshalJSONNumber)
 
 	if err := d.Decode(&m); err != nil {
 		return nil, err

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/claims.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/claims.go
@@ -26,31 +26,33 @@ import (
 
 // Claims represents public claim values (as specified in RFC 7519).
 type Claims struct {
-	Issuer    string      `json:"iss,omitempty"`
-	Subject   string      `json:"sub,omitempty"`
-	Audience  Audience    `json:"aud,omitempty"`
-	Expiry    NumericDate `json:"exp,omitempty"`
-	NotBefore NumericDate `json:"nbf,omitempty"`
-	IssuedAt  NumericDate `json:"iat,omitempty"`
-	ID        string      `json:"jti,omitempty"`
+	Issuer    string       `json:"iss,omitempty"`
+	Subject   string       `json:"sub,omitempty"`
+	Audience  Audience     `json:"aud,omitempty"`
+	Expiry    *NumericDate `json:"exp,omitempty"`
+	NotBefore *NumericDate `json:"nbf,omitempty"`
+	IssuedAt  *NumericDate `json:"iat,omitempty"`
+	ID        string       `json:"jti,omitempty"`
 }
 
 // NumericDate represents date and time as the number of seconds since the
-// epoch, including leap seconds. Non-integer values can be represented
+// epoch, ignoring leap seconds. Non-integer values can be represented
 // in the serialized format, but we round to the nearest second.
+// See RFC7519 Section 2: https://tools.ietf.org/html/rfc7519#section-2
 type NumericDate int64
 
 // NewNumericDate constructs NumericDate from time.Time value.
-func NewNumericDate(t time.Time) NumericDate {
+func NewNumericDate(t time.Time) *NumericDate {
 	if t.IsZero() {
-		return NumericDate(0)
+		return nil
 	}
 
 	// While RFC 7519 technically states that NumericDate values may be
 	// non-integer values, we don't bother serializing timestamps in
 	// claims with sub-second accurancy and just round to the nearest
 	// second instead. Not convined sub-second accuracy is useful here.
-	return NumericDate(t.Unix())
+	out := NumericDate(t.Unix())
+	return &out
 }
 
 // MarshalJSON serializes the given NumericDate into its JSON representation.
@@ -72,11 +74,14 @@ func (n *NumericDate) UnmarshalJSON(b []byte) error {
 }
 
 // Time returns time.Time representation of NumericDate.
-func (n NumericDate) Time() time.Time {
-	return time.Unix(int64(n), 0)
+func (n *NumericDate) Time() time.Time {
+	if n == nil {
+		return time.Time{}
+	}
+	return time.Unix(int64(*n), 0)
 }
 
-// Audience represents the recipents that the token is intended for.
+// Audience represents the recipients that the token is intended for.
 type Audience []string
 
 // UnmarshalJSON reads an audience from its JSON representation.

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/errors.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/errors.go
@@ -46,5 +46,8 @@ var ErrNotValidYet = errors.New("square/go-jose/jwt: validation failed, token no
 // ErrExpired indicates that token is used after expiry time indicated in exp claim.
 var ErrExpired = errors.New("square/go-jose/jwt: validation failed, token is expired (exp)")
 
-// ErrInvalidContentType indicated that token requires JWT cty header.
+// ErrIssuedInTheFuture indicates that the iat field is in the future.
+var ErrIssuedInTheFuture = errors.New("square/go-jose/jwt: validation field, token issued in the future (iat)")
+
+// ErrInvalidContentType indicates that token requires JWT cty header.
 var ErrInvalidContentType = errors.New("square/go-jose/jwt: expected content type to be JWT (cty header)")

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/jwt.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/jwt.go
@@ -19,9 +19,10 @@ package jwt
 
 import (
 	"fmt"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/json"
 	"strings"
+
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/json"
 )
 
 // JSONWebToken represents a JSON Web Token (as specified in RFC7519).
@@ -38,7 +39,9 @@ type NestedJSONWebToken struct {
 
 // Claims deserializes a JSONWebToken into dest using the provided key.
 func (t *JSONWebToken) Claims(key interface{}, dest ...interface{}) error {
-	b, err := t.payload(key)
+	payloadKey := tryJWKS(t.Headers, key)
+
+	b, err := t.payload(payloadKey)
 	if err != nil {
 		return err
 	}
@@ -69,7 +72,9 @@ func (t *JSONWebToken) UnsafeClaimsWithoutVerification(dest ...interface{}) erro
 }
 
 func (t *NestedJSONWebToken) Decrypt(decryptionKey interface{}) (*JSONWebToken, error) {
-	b, err := t.enc.Decrypt(decryptionKey)
+	key := tryJWKS(t.Headers, decryptionKey)
+
+	b, err := t.enc.Decrypt(key)
 	if err != nil {
 		return nil, err
 	}
@@ -129,4 +134,36 @@ func ParseSignedAndEncrypted(s string) (*NestedJSONWebToken, error) {
 		enc:     enc,
 		Headers: []jose.Header{enc.Header},
 	}, nil
+}
+
+func tryJWKS(headers []jose.Header, key interface{}) interface{} {
+	var jwks jose.JSONWebKeySet
+
+	switch jwksType := key.(type) {
+	case *jose.JSONWebKeySet:
+		jwks = *jwksType
+	case jose.JSONWebKeySet:
+		jwks = jwksType
+	default:
+		return key
+	}
+
+	var kid string
+	for _, header := range headers {
+		if header.KeyID != "" {
+			kid = header.KeyID
+			break
+		}
+	}
+
+	if kid == "" {
+		return key
+	}
+
+	keys := jwks.Key(kid)
+	if len(keys) == 0 {
+		return key
+	}
+
+	return keys[0].Key
 }

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/validation.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/validation.go
@@ -35,7 +35,7 @@ type Expected struct {
 	Audience Audience
 	// ID matches the "jti" claim exactly.
 	ID string
-	// Time matches the "exp" and "nbf" claims with leeway.
+	// Time matches the "exp", "nbf" and "iat" claims with leeway.
 	Time time.Time
 }
 
@@ -94,12 +94,20 @@ func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 		}
 	}
 
-	if !e.Time.IsZero() && e.Time.Add(leeway).Before(c.NotBefore.Time()) {
-		return ErrNotValidYet
-	}
+	if !e.Time.IsZero() {
+		if c.NotBefore != nil && e.Time.Add(leeway).Before(c.NotBefore.Time()) {
+			return ErrNotValidYet
+		}
 
-	if !e.Time.IsZero() && e.Time.Add(-leeway).After(c.Expiry.Time()) {
-		return ErrExpired
+		if c.Expiry != nil && e.Time.Add(-leeway).After(c.Expiry.Time()) {
+			return ErrExpired
+		}
+
+		// IssuedAt is optional but cannot be in the future. This is not required by the RFC, but
+		// something is misconfigured if this happens and we should not trust it.
+		if c.IssuedAt != nil && e.Time.Add(leeway).Before(c.IssuedAt.Time()) {
+			return ErrIssuedInTheFuture
+		}
 	}
 
 	return nil

--- a/vendor/gopkg.in/square/go-jose.v2/opaque.go
+++ b/vendor/gopkg.in/square/go-jose.v2/opaque.go
@@ -17,7 +17,7 @@
 package jose
 
 // OpaqueSigner is an interface that supports signing payloads with opaque
-// private key(s). Private key operations preformed by implementors may, for
+// private key(s). Private key operations performed by implementers may, for
 // example, occur in a hardware module. An OpaqueSigner may rotate signing keys
 // transparently to the user of this interface.
 type OpaqueSigner interface {
@@ -80,4 +80,65 @@ type opaqueVerifier struct {
 
 func (o *opaqueVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
 	return o.verifier.VerifyPayload(payload, signature, alg)
+}
+
+// OpaqueKeyEncrypter is an interface that supports encrypting keys with an opaque key.
+type OpaqueKeyEncrypter interface {
+	// KeyID returns the kid
+	KeyID() string
+	// Algs returns a list of supported key encryption algorithms.
+	Algs() []KeyAlgorithm
+	// encryptKey encrypts the CEK using the given algorithm.
+	encryptKey(cek []byte, alg KeyAlgorithm) (recipientInfo, error)
+}
+
+type opaqueKeyEncrypter struct {
+	encrypter OpaqueKeyEncrypter
+}
+
+func newOpaqueKeyEncrypter(alg KeyAlgorithm, encrypter OpaqueKeyEncrypter) (recipientKeyInfo, error) {
+	var algSupported bool
+	for _, salg := range encrypter.Algs() {
+		if alg == salg {
+			algSupported = true
+			break
+		}
+	}
+	if !algSupported {
+		return recipientKeyInfo{}, ErrUnsupportedAlgorithm
+	}
+
+	return recipientKeyInfo{
+		keyID:  encrypter.KeyID(),
+		keyAlg: alg,
+		keyEncrypter: &opaqueKeyEncrypter{
+			encrypter: encrypter,
+		},
+	}, nil
+}
+
+func (oke *opaqueKeyEncrypter) encryptKey(cek []byte, alg KeyAlgorithm) (recipientInfo, error) {
+	return oke.encrypter.encryptKey(cek, alg)
+}
+
+//OpaqueKeyDecrypter is an interface that supports decrypting keys with an opaque key.
+type OpaqueKeyDecrypter interface {
+	DecryptKey(encryptedKey []byte, header Header) ([]byte, error)
+}
+
+type opaqueKeyDecrypter struct {
+	decrypter OpaqueKeyDecrypter
+}
+
+func (okd *opaqueKeyDecrypter) decryptKey(headers rawHeader, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+	mergedHeaders := rawHeader{}
+	mergedHeaders.merge(&headers)
+	mergedHeaders.merge(recipient.header)
+
+	header, err := mergedHeaders.sanitized()
+	if err != nil {
+		return nil, err
+	}
+
+	return okd.decrypter.DecryptKey(recipient.encryptedKey, header)
 }

--- a/vendor/gopkg.in/square/go-jose.v2/shared.go
+++ b/vendor/gopkg.in/square/go-jose.v2/shared.go
@@ -153,11 +153,17 @@ const (
 	headerJWK   = "jwk"   // *JSONWebKey
 	headerKeyID = "kid"   // string
 	headerNonce = "nonce" // string
+	headerB64   = "b64"   // bool
 
 	headerP2C = "p2c" // *byteBuffer (int)
 	headerP2S = "p2s" // *byteBuffer ([]byte)
 
 )
+
+// supportedCritical is the set of supported extensions that are understood and processed.
+var supportedCritical = map[string]bool{
+	headerB64: true,
+}
 
 // rawHeader represents the JOSE header for JWE/JWS objects (used for parsing).
 //
@@ -177,7 +183,7 @@ type Header struct {
 	// Unverified certificate chain parsed from x5c header.
 	certificates []*x509.Certificate
 
-	// Any headers not recognised above get unmarshaled
+	// Any headers not recognised above get unmarshalled
 	// from JSON in a generic manner and placed in this map.
 	ExtraHeaders map[HeaderKey]interface{}
 }
@@ -289,12 +295,12 @@ func (parsed rawHeader) getAPV() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerAPV)
 }
 
-// getIV extracts parsed "iv" frpom the raw JSON.
+// getIV extracts parsed "iv" from the raw JSON.
 func (parsed rawHeader) getIV() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerIV)
 }
 
-// getTag extracts parsed "tag" frpom the raw JSON.
+// getTag extracts parsed "tag" from the raw JSON.
 func (parsed rawHeader) getTag() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerTag)
 }
@@ -347,6 +353,21 @@ func (parsed rawHeader) getP2C() (int, error) {
 // getS2S extracts parsed "p2s" from the raw JSON.
 func (parsed rawHeader) getP2S() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerP2S)
+}
+
+// getB64 extracts parsed "b64" from the raw JSON, defaulting to true.
+func (parsed rawHeader) getB64() (bool, error) {
+	v := parsed[headerB64]
+	if v == nil {
+		return true, nil
+	}
+
+	var b64 bool
+	err := json.Unmarshal(*v, &b64)
+	if err != nil {
+		return true, err
+	}
+	return b64, nil
 }
 
 // sanitized produces a cleaned-up header object from the raw JSON.

--- a/vendor/gopkg.in/square/go-jose.v2/signing.go
+++ b/vendor/gopkg.in/square/go-jose.v2/signing.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/base64"
@@ -75,6 +76,27 @@ func (so *SignerOptions) WithContentType(contentType ContentType) *SignerOptions
 // WithType adds a type ("typ") header and returns the updated SignerOptions.
 func (so *SignerOptions) WithType(typ ContentType) *SignerOptions {
 	return so.WithHeader(HeaderType, typ)
+}
+
+// WithCritical adds the given names to the critical ("crit") header and returns
+// the updated SignerOptions.
+func (so *SignerOptions) WithCritical(names ...string) *SignerOptions {
+	if so.ExtraHeaders[headerCritical] == nil {
+		so.WithHeader(headerCritical, make([]string, 0, len(names)))
+	}
+	crit := so.ExtraHeaders[headerCritical].([]string)
+	so.ExtraHeaders[headerCritical] = append(crit, names...)
+	return so
+}
+
+// WithBase64 adds a base64url-encode payload ("b64") header and returns the updated
+// SignerOptions. When the "b64" value is "false", the payload is not base64 encoded.
+func (so *SignerOptions) WithBase64(b64 bool) *SignerOptions {
+	if !b64 {
+		so.WithHeader(headerB64, b64)
+		so.WithCritical(headerB64)
+	}
+	return so
 }
 
 type payloadSigner interface {
@@ -233,7 +255,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JSONWebSignature, error) {
 			if ctx.embedJWK {
 				protected[headerJWK] = recipient.publicKey()
 			} else {
-				protected[headerKeyID] = recipient.publicKey().KeyID
+				keyID := recipient.publicKey().KeyID
+				if keyID != "" {
+					protected[headerKeyID] = keyID
+				}
 			}
 		}
 
@@ -250,12 +275,26 @@ func (ctx *genericSigner) Sign(payload []byte) (*JSONWebSignature, error) {
 		}
 
 		serializedProtected := mustSerializeJSON(protected)
+		needsBase64 := true
 
-		input := []byte(fmt.Sprintf("%s.%s",
-			base64.RawURLEncoding.EncodeToString(serializedProtected),
-			base64.RawURLEncoding.EncodeToString(payload)))
+		if b64, ok := protected[headerB64]; ok {
+			if needsBase64, ok = b64.(bool); !ok {
+				return nil, errors.New("square/go-jose: Invalid b64 header parameter")
+			}
+		}
 
-		signatureInfo, err := recipient.signer.signPayload(input, recipient.sigAlg)
+		var input bytes.Buffer
+
+		input.WriteString(base64.RawURLEncoding.EncodeToString(serializedProtected))
+		input.WriteByte('.')
+
+		if needsBase64 {
+			input.WriteString(base64.RawURLEncoding.EncodeToString(payload))
+		} else {
+			input.Write(payload)
+		}
+
+		signatureInfo, err := recipient.signer.signPayload(input.Bytes(), recipient.sigAlg)
 		if err != nil {
 			return nil, err
 		}
@@ -324,12 +363,18 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 	if err != nil {
 		return err
 	}
-	if len(critical) > 0 {
-		// Unsupported crit header
+
+	for _, name := range critical {
+		if !supportedCritical[name] {
+			return ErrCryptoFailure
+		}
+	}
+
+	input, err := obj.computeAuthData(payload, &signature)
+	if err != nil {
 		return ErrCryptoFailure
 	}
 
-	input := obj.computeAuthData(payload, &signature)
 	alg := headers.getSignatureAlgorithm()
 	err = verifier.verifyPayload(input, signature.Signature, alg)
 	if err == nil {
@@ -366,18 +411,25 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 		return -1, Signature{}, err
 	}
 
+outer:
 	for i, signature := range obj.Signatures {
 		headers := signature.mergedHeaders()
 		critical, err := headers.getCritical()
 		if err != nil {
 			continue
 		}
-		if len(critical) > 0 {
-			// Unsupported crit header
+
+		for _, name := range critical {
+			if !supportedCritical[name] {
+				continue outer
+			}
+		}
+
+		input, err := obj.computeAuthData(payload, &signature)
+		if err != nil {
 			continue
 		}
 
-		input := obj.computeAuthData(payload, &signature)
 		alg := headers.getSignatureAlgorithm()
 		err = verifier.verifyPayload(input, signature.Signature, alg)
 		if err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -826,7 +826,7 @@ google.golang.org/protobuf/types/known/wrapperspb
 # gopkg.in/inf.v0 v0.9.1
 ## explicit
 gopkg.in/inf.v0
-# gopkg.in/square/go-jose.v2 v2.6.0 => gopkg.in/square/go-jose.v2 v2.2.2
+# gopkg.in/square/go-jose.v2 v2.6.0 => github.com/go-jose/go-jose v2.6.0+incompatible
 ## explicit
 gopkg.in/square/go-jose.v2
 gopkg.in/square/go-jose.v2/cipher
@@ -1754,3 +1754,4 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.26.1
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.1
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.1
+# github.com/go-jose/go-jose.v2 => github.com/go-jose/go-jose v2.6.3+incompatible


### PR DESCRIPTION
This commit replaces all the references of [github.com/square/go-jose](https://github.com/square/go-jose) to [github.com/go-jose/go-jose@v2](https://github.com/go-jose/go-jose).

Manual cherry-pick of https://github.com/openshift/openshift-controller-manager/pull/342 