### PR TITLE
OCPBUGS-56474: Empty proxy variables are causing issues during the build

### DIFF
--- a/pkg/build/controller/build/defaults/defaults.go
+++ b/pkg/build/controller/build/defaults/defaults.go
@@ -27,7 +27,7 @@ func (b BuildDefaults) ApplyDefaults(pod *corev1.Pod) error {
 		return nil
 	}
 
-	if b.DefaultProxy != nil {
+	if b.DefaultProxy != nil && (b.DefaultProxy.HTTPProxy != "" || b.DefaultProxy.HTTPSProxy != "" || b.DefaultProxy.NoProxy != "") {
 		b.applyPodProxyDefaults(pod, build.Spec.Strategy.CustomStrategy != nil)
 	}
 
@@ -95,9 +95,18 @@ func (b BuildDefaults) applyPodProxyDefaults(pod *corev1.Pod, isCustomBuild bool
 		// All env vars are allowed to be set in a custom build pod, the user already has
 		// total control over the env+logic in a custom build pod anyway.
 		externalEnv := []corev1.EnvVar{}
-		externalEnv = append(externalEnv, corev1.EnvVar{Name: "HTTP_PROXY", Value: b.DefaultProxy.HTTPProxy})
-		externalEnv = append(externalEnv, corev1.EnvVar{Name: "HTTPS_PROXY", Value: b.DefaultProxy.HTTPSProxy})
-		externalEnv = append(externalEnv, corev1.EnvVar{Name: "NO_PROXY", Value: b.DefaultProxy.NoProxy})
+		if b.DefaultProxy.HTTPProxy != "" {
+			externalEnv = append(externalEnv, corev1.EnvVar{Name: "HTTP_PROXY", Value: b.DefaultProxy.HTTPProxy})
+			externalEnv = append(externalEnv, corev1.EnvVar{Name: "http_proxy", Value: b.DefaultProxy.HTTPProxy})
+		}
+		if b.DefaultProxy.HTTPSProxy != "" {
+			externalEnv = append(externalEnv, corev1.EnvVar{Name: "HTTPS_PROXY", Value: b.DefaultProxy.HTTPSProxy})
+			externalEnv = append(externalEnv, corev1.EnvVar{Name: "https_proxy", Value: b.DefaultProxy.HTTPSProxy})
+		}
+		if b.DefaultProxy.NoProxy != "" {
+			externalEnv = append(externalEnv, corev1.EnvVar{Name: "NO_PROXY", Value: b.DefaultProxy.NoProxy})
+			externalEnv = append(externalEnv, corev1.EnvVar{Name: "no_proxy", Value: b.DefaultProxy.NoProxy})
+		}
 
 		if isCustomBuild {
 			buildutil.MergeEnvWithoutDuplicates(externalEnv, &c.Env, false, []string{})


### PR DESCRIPTION
Problem:
Irrespective of default proxy settings these proxy variables are set on build containers. If any defaults are set they reflect those setting ,if not set they are set to null on the build container. Having these null variables are causing problems to some customers as its breaking some required apps on container HTTP_PROXY,http_proxy,HTTPS_PROXY,https_proxy,NO_PROXY,no_proxy

Fix:
Code changed only to add these proxy variables only if they are defined in defaults and if they are not null.