### PR TITLE
WRKLDS-1676:  pkg/cmd: Add --kubeconfig and --namespace flag

### DIFF
--- a/pkg/cmd/openshift-controller-manager/cmd.go
+++ b/pkg/cmd/openshift-controller-manager/cmd.go
@@ -27,8 +27,10 @@ import (
 )
 
 type OpenShiftControllerManager struct {
-	ConfigFilePath string
-	Output         io.Writer
+	ConfigFilePath     string
+	KubeConfigFilePath string
+	Namespace          string
+	Output             io.Writer
 }
 
 var longDescription = templates.LongDesc(`
@@ -64,8 +66,12 @@ func NewOpenShiftControllerManagerCommand(name string, out, errout io.Writer, ct
 	flags := cmd.Flags()
 	// This command only supports reading from config
 	flags.StringVar(&options.ConfigFilePath, "config", options.ConfigFilePath, "Location of the master configuration file to run from.")
+	flags.StringVar(&options.KubeConfigFilePath, "kubeconfig", options.KubeConfigFilePath, "This flag is ignored.")
+	flags.StringVar(&options.Namespace, "namespace", options.Namespace, "This flag is ignored.")
 	cmd.MarkFlagFilename("config", "yaml", "yml")
 	cmd.MarkFlagRequired("config")
+	cmd.Flags().MarkHidden("kubeconfig")
+	cmd.Flags().MarkHidden("namespace")
 
 	return cmd
 }


### PR DESCRIPTION
This is needed as a temporary solution to be able to align
Hypershift OCM configuration for future compatibility with library-go.
    
The flags are currently being ignored.

This is going to be followed by applying https://github.com/openshift/hypershift/compare/main...tchap:hypershift:ocm-kubeconfig

Blocking https://github.com/openshift/openshift-controller-manager/pull/378