### PR TITLE
[release-4.19] OCPBUGS-57193: Set node-pullsecrets volume to read-only to protect image pull credentials

### DIFF
--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -80,6 +80,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 						{
 							Name:      "node-pullsecrets",
 							MountPath: buildutil.NodePullSecretsPath,
+							ReadOnly:  true,
 						},
 						{
 							Name:      "buildworkdir",
@@ -163,6 +164,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 				{
 					Name:      "node-pullsecrets",
 					MountPath: buildutil.NodePullSecretsPath,
+					ReadOnly:  true,
 				},
 				{
 					Name:      "buildworkdir",

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -90,6 +90,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 						{
 							Name:      "node-pullsecrets",
 							MountPath: buildutil.NodePullSecretsPath,
+							ReadOnly:  true,
 						},
 						{
 							Name:      "buildworkdir",
@@ -170,6 +171,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 				{
 					Name:      "node-pullsecrets",
 					MountPath: buildutil.NodePullSecretsPath,
+					ReadOnly:  true,
 				},
 				{
 					Name:      "buildworkdir",


### PR DESCRIPTION
This sets `ReadOnly: true` on the `node-pullsecrets`  volume to prevent pods from overwriting `/var/lib/kubelet/config.json`, which could cause image pull failures and expose sensitive credentials. This change is applied to both Docker and Source-to-Image build strategies.