### PR TITLE
OCPBUGS-55650: Drop BuildCSIVolumes feature gate logic (Build CSI Volumes in OpenShift Builds is GA since 4.14) 

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -196,7 +196,6 @@ type BuildController struct {
 	buildDefaults            builddefaults.BuildDefaults
 	buildOverrides           buildoverrides.BuildOverrides
 	internalRegistryHostname string
-	buildCSIVolumesEnabled   bool
 
 	recorder                record.EventRecorder
 	registryConfData        string

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -26,8 +26,7 @@ func init() {
 
 // DockerBuildStrategy creates a Docker build using a Docker builder image.
 type DockerBuildStrategy struct {
-	Image                  string
-	BuildCSIVolumesEnabled bool
+	Image string
 }
 
 // CreateBuildPod creates the pod to be used for the Docker build
@@ -219,7 +218,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		setupBuilderDeviceFUSE(pod)
 	}
 	setupBlobCache(pod)
-	if err := setupBuildVolumes(pod, build.Spec.Strategy.DockerStrategy.Volumes, bs.BuildCSIVolumesEnabled); err != nil {
+	if err := setupBuildVolumes(pod, build.Spec.Strategy.DockerStrategy.Volumes); err != nil {
 		return pod, err
 	}
 	return pod, nil

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -18,9 +18,8 @@ import (
 
 // SourceBuildStrategy creates STI(source to image) builds
 type SourceBuildStrategy struct {
-	Image                   string
-	SecurityClient          securityclient.SecurityV1Interface
-	BuildCSIVolumeseEnabled bool
+	Image          string
+	SecurityClient securityclient.SecurityV1Interface
 }
 
 // DefaultDropCaps is the list of capabilities to drop if the current user cannot run as root
@@ -226,7 +225,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 		setupBuilderDeviceFUSE(pod)
 	}
 	setupBlobCache(pod)
-	if err := setupBuildVolumes(pod, build.Spec.Strategy.SourceStrategy.Volumes, bs.BuildCSIVolumeseEnabled); err != nil {
+	if err := setupBuildVolumes(pod, build.Spec.Strategy.SourceStrategy.Volumes); err != nil {
 		return pod, err
 	}
 	return pod, nil

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -755,7 +755,7 @@ func setupBlobCache(pod *corev1.Pod) {
 }
 
 // setupBuildVolumes sets up user defined BuildVolumes
-func setupBuildVolumes(pod *corev1.Pod, buildVolumes []buildv1.BuildVolume, csiVolumesEnabled bool) error {
+func setupBuildVolumes(pod *corev1.Pod, buildVolumes []buildv1.BuildVolume) error {
 	// if there are no BuildVolumes or the pod is nil,
 	// there is no processing needed, so just return quickly
 	if len(buildVolumes) == 0 || pod == nil {
@@ -791,9 +791,6 @@ func setupBuildVolumes(pod *corev1.Pod, buildVolumes []buildv1.BuildVolume, csiV
 			volumeSource.ConfigMap = buildVolume.Source.ConfigMap
 			mountConfigMapVolume(pod, &pod.Spec.Containers[0], strings.ToLower(buildVolume.Source.ConfigMap.Name), PathForBuildVolume(buildVolume.Source.ConfigMap.Name), buildVolumeSuffix, &volumeSource)
 		case buildv1.BuildVolumeSourceTypeCSI:
-			if !csiVolumesEnabled {
-				return fmt.Errorf("csi volumes require the BuildCSIVolumes feature gate to be enabled")
-			}
 			volumeSource.CSI = buildVolume.Source.CSI
 			mountCSIVolume(pod, &pod.Spec.Containers[0], strings.ToLower(buildVolume.Name), PathForBuildVolume(buildVolume.Name), buildVolumeSuffix, &volumeSource)
 		default:

--- a/pkg/build/controller/strategy/util_test.go
+++ b/pkg/build/controller/strategy/util_test.go
@@ -542,7 +542,6 @@ func TestSetupBuildVolumes(t *testing.T) {
 
 	tests := []struct {
 		Name                 string
-		CSIVolumeEnabled     bool
 		ShouldFail           bool
 		ErrorMessage         string
 		StartingVolumes      []corev1.Volume
@@ -552,10 +551,9 @@ func TestSetupBuildVolumes(t *testing.T) {
 		WantVolumeMounts     []corev1.VolumeMount
 	}{
 		{
-			Name:             "Secret BuildVolume should succeed",
-			CSIVolumeEnabled: false,
-			ShouldFail:       false,
-			ErrorMessage:     "",
+			Name:         "Secret BuildVolume should succeed",
+			ShouldFail:   false,
+			ErrorMessage: "",
 			BuildVolumes: []buildv1.BuildVolume{
 				{
 					Name: "one",
@@ -606,10 +604,9 @@ func TestSetupBuildVolumes(t *testing.T) {
 			},
 		},
 		{
-			Name:             "ConfigMap BuildVolume should succeed",
-			CSIVolumeEnabled: false,
-			ShouldFail:       false,
-			ErrorMessage:     "",
+			Name:         "ConfigMap BuildVolume should succeed",
+			ShouldFail:   false,
+			ErrorMessage: "",
 			BuildVolumes: []buildv1.BuildVolume{
 				{
 					Name: "one",
@@ -660,10 +657,9 @@ func TestSetupBuildVolumes(t *testing.T) {
 			},
 		},
 		{
-			Name:             "CSI BuildVolume should succeed",
-			CSIVolumeEnabled: true,
-			ShouldFail:       false,
-			ErrorMessage:     "",
+			Name:         "CSI BuildVolume should succeed",
+			ShouldFail:   false,
+			ErrorMessage: "",
 			BuildVolumes: []buildv1.BuildVolume{
 				{
 					Name: "csi-one",
@@ -702,10 +698,9 @@ func TestSetupBuildVolumes(t *testing.T) {
 			},
 		},
 		{
-			Name:             "Duplicate Secret BuildVolumeMount should fail",
-			CSIVolumeEnabled: false,
-			ShouldFail:       true,
-			ErrorMessage:     "user provided BuildVolumeMount path \"my-path\" collides with VolumeMount path created by the build controller",
+			Name:         "Duplicate Secret BuildVolumeMount should fail",
+			ShouldFail:   true,
+			ErrorMessage: "user provided BuildVolumeMount path \"my-path\" collides with VolumeMount path created by the build controller",
 			StartingVolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "some-name",
@@ -746,10 +741,9 @@ func TestSetupBuildVolumes(t *testing.T) {
 			},
 		},
 		{
-			Name:             "UnSupported BuildVolumeSourceType should fail",
-			CSIVolumeEnabled: false,
-			ShouldFail:       true,
-			ErrorMessage:     "encountered unsupported build volume source type \"UnSupportedBuildVolumeType\"",
+			Name:         "UnSupported BuildVolumeSourceType should fail",
+			ShouldFail:   true,
+			ErrorMessage: "encountered unsupported build volume source type \"UnSupportedBuildVolumeType\"",
 			BuildVolumes: []buildv1.BuildVolume{
 				{
 					Name: "one",
@@ -758,31 +752,6 @@ func TestSetupBuildVolumes(t *testing.T) {
 						Secret: &corev1.SecretVolumeSource{},
 					},
 					Mounts: []buildv1.BuildVolumeMount{},
-				},
-			},
-			WantVolumes:      []corev1.Volume{},
-			WantVolumeMounts: []corev1.VolumeMount{},
-		},
-		{
-			Name:             "CSI volume request without csivolumeEnabled should fail",
-			CSIVolumeEnabled: false,
-			ShouldFail:       true,
-			ErrorMessage:     "csi volumes require the BuildCSIVolumes feature gate to be enabled",
-			BuildVolumes: []buildv1.BuildVolume{
-				{
-					Name: "csi-one",
-					Source: buildv1.BuildVolumeSource{
-						Type: buildv1.BuildVolumeSourceTypeCSI,
-						CSI: &corev1.CSIVolumeSource{
-							Driver:           "inline.storage.kubernetes.io",
-							VolumeAttributes: map[string]string{"foo": "bar"},
-						},
-					},
-					Mounts: []buildv1.BuildVolumeMount{
-						{
-							DestinationPath: "my-path",
-						},
-					},
 				},
 			},
 			WantVolumes:      []corev1.Volume{},
@@ -802,7 +771,7 @@ func TestSetupBuildVolumes(t *testing.T) {
 				p.Spec.Containers[0].VolumeMounts = append(p.Spec.Containers[0].VolumeMounts, tt.StartingVolumeMounts...)
 			}
 
-			err := setupBuildVolumes(p, tt.BuildVolumes, tt.CSIVolumeEnabled)
+			err := setupBuildVolumes(p, tt.BuildVolumes)
 
 			if err == nil && tt.ShouldFail {
 				t.Errorf("test %q should have failed with error %q, but didn't", tt.Name, tt.ErrorMessage)

--- a/pkg/cmd/controller/build.go
+++ b/pkg/cmd/controller/build.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"strings"
-
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
@@ -53,17 +51,6 @@ func RunBuildController(ctx *ControllerContext) (bool, error) {
 	imageDigestMirrorSetInformer := ctx.ConfigInformers.Config().V1().ImageDigestMirrorSets()
 	imageTagMirrorSetInformer := ctx.ConfigInformers.Config().V1().ImageTagMirrorSets()
 
-	fg := ctx.OpenshiftControllerConfig.FeatureGates
-	csiVolumesEnabled := false
-	if fg != nil {
-		for _, v := range fg {
-			v = strings.TrimSpace(v)
-			if v == "BuildCSIVolumes=true" {
-				csiVolumesEnabled = true
-			}
-		}
-	}
-
 	buildControllerParams := &buildcontroller.BuildControllerParams{
 		BuildInformer:                      buildInformer,
 		BuildConfigInformer:                buildConfigInformer,
@@ -83,13 +70,11 @@ func RunBuildController(ctx *ControllerContext) (bool, error) {
 		KubeClient:                         externalKubeClient,
 		BuildClient:                        buildClient,
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
-			Image:                  imageTemplate.ExpandOrDie("docker-builder"),
-			BuildCSIVolumesEnabled: csiVolumesEnabled,
+			Image: imageTemplate.ExpandOrDie("docker-builder"),
 		},
 		SourceBuildStrategy: &buildstrategy.SourceBuildStrategy{
-			Image:                   imageTemplate.ExpandOrDie("docker-builder"),
-			SecurityClient:          securityClient.SecurityV1(),
-			BuildCSIVolumeseEnabled: csiVolumesEnabled,
+			Image:          imageTemplate.ExpandOrDie("docker-builder"),
+			SecurityClient: securityClient.SecurityV1(),
 		},
 		CustomBuildStrategy:      &buildstrategy.CustomBuildStrategy{},
 		BuildDefaults:            builddefaults.BuildDefaults{Config: ctx.OpenshiftControllerConfig.Build.BuildDefaults},


### PR DESCRIPTION
This PR removes all logic related to the BuildCSIVolumes feature gate from the openshift-controller-manager.

The BuildCSIVolumesEnabled flag along with its parsing logic, conditional checks, and related test cases has been fully removed. CSI volume support in Build pods is now considered stable and enabled by default, requiring no feature gate.

Originally, the BuildCSIVolumes feature gate was introduced to conditionally enable CSI (Container Storage Interface) volume mounts in Build pods. However, this functionality became generally available (GA) and permanently enabled starting with OpenShift 4.14, rendering the feature gate unnecessary.

As mounting CSI volumes into Build pods is now a standard, fully supported capability, all gate-specific logic is unnecessary and has been cleaned up.

With this change, the BuildCSIVolumes gate is no longer referenced and can also be safely removed from the openshift/api repo.