### PR TITLE
OCPBUGS-61899: CNTRLPLANE-1308: Fix Dockerfile.rhel: Add OTE binary build and packaging

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,10 +1,13 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
-RUN make build --warn-undefined-variables
+RUN make build --warn-undefined-variables \
+    && make tests-ext-build \
+    && gzip openshift-controller-manager-tests-ext
 
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/openshift-controller-manager/openshift-controller-manager /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/openshift-controller-manager/openshift-controller-manager-tests-ext.gz /usr/bin/
 LABEL io.k8s.display-name="OpenShift Controller Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,openshift-controller-manager"


### PR DESCRIPTION
- Add tests-ext-build target to container build process
- Gzip the openshift-controller-manager-tests-ext binary
- Copy gzipped OTE binary to /usr/bin/ in final image
- Fixes CI error: openshift-controller-manager-tests-ext.gz missing from container
```
to fix below error
  nfo msg="Using existing binary /tmp/secret/.cache/openshift-tests/registry_build10_ci_openshift_org_ci-op-xj8ftkjz_release_sha256_534704bae289bb42d63c2a03f2bdaf367b906812a22bb555fd8ff0cdf838c862_b7711a98d9f9/openshift-apiserver-tests-ext for tag openshift-apiserver"
time="2025-09-18T07:31:02Z" level=info msg="Using existing binary /tmp/secret/.cache/openshift-tests/registry_build10_ci_openshift_org_ci-op-xj8ftkjz_release_sha256_534704bae289bb42d63c2a03f2bdaf367b906812a22bb555fd8ff0cdf838c862_b7711a98d9f9/machine-api-tests-ext for tag machine-api-operator"
time="2025-09-18T07:31:06Z" level=info msg="Completed image extract for release image \"quay-proxy.ci.openshift.org/openshift/ci@sha256:955f60e894a7beb961b2fa48e7d43ea87dac695dd54cd4639848fe02f6c7a555\" in 3.982108662s"
error: couldn't retrieve test suites: failed to extract test binaries: encountered errors while extracting binaries: extracted binary at path "/tmp/secret/.cache/openshift-tests/registry_build10_ci_openshift_org_ci-op-xj8ftkjz_release_sha256_534704bae289bb42d63c2a03f2bdaf367b906812a22bb555fd8ff0cdf838c862_b7711a98d9f9/openshift-controller-manager-tests-ext.gz" does not exist. the src path "/usr/bin/openshift-controller-manager-tests-ext.gz" doesn't exist in image "quay-proxy.ci.openshift.org/openshift/ci@sha256:955f60e894a7beb961b2fa48e7d43ea87dac695dd54cd4639848fe02f6c7a555". note the version of origin needs to match the version of the cluster under test
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2025-09-18T07:31:06Z"}
time="2025-09-18T07:31:06Z" level=warning msg="skipped directory \".cache\" when creating secret from directory \"/tmp/secret\""
time="2025-09-18T07:31:06Z" level=warning msg="skipped directory \".kube\" when creating secret from directory \"/tmp/secret\""
error: failed to execute wrapped command: exit status 1
}
```