### PR TITLE
OCPBUGS-61900:Fix Dockerfile.rhel: Add OTE binary build and packaging for release-4.20

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,10 +1,13 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-controller-manager
 COPY . .
-RUN make build --warn-undefined-variables
+RUN make build --warn-undefined-variables \
+    && make tests-ext-build \
+    && gzip openshift-controller-manager-tests-ext
 
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/openshift-controller-manager/openshift-controller-manager /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/openshift-controller-manager/openshift-controller-manager-tests-ext.gz /usr/bin/
 LABEL io.k8s.display-name="OpenShift Controller Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,openshift-controller-manager"


### PR DESCRIPTION
- Add tests-ext-build target to container build process
- Gzip the openshift-controller-manager-tests-ext binary
- Copy gzipped OTE binary to /usr/bin/ in final image
- Fixes CI error: openshift-controller-manager-tests-ext.gz missing from container

This ensures the OTE binary is available for CI test execution on release-4.20.