### PR TITLE
CNF-23051: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -3,7 +3,6 @@ package build
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -1761,7 +1760,7 @@ func TestHandleControllerConfig(t *testing.T) {
 			}
 
 			// Ensure that the generated configuration is actually valid.
-			registriesConf, err := ioutil.TempFile("", "registries.conf")
+			registriesConf, err := os.CreateTemp("", "registries.conf")
 			defer os.Remove(registriesConf.Name())
 			if err != nil {
 				t.Errorf("unexpected error creating temp file: %s", err.Error())

--- a/pkg/image/controller/imagestream_controller_test.go
+++ b/pkg/image/controller/imagestream_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -478,7 +477,7 @@ func objBody(object interface{}) io.ReadCloser {
 	if err != nil {
 		panic(err)
 	}
-	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
+	return io.NopCloser(bytes.NewReader([]byte(output)))
 }
 
 func header() http.Header {
@@ -488,7 +487,7 @@ func header() http.Header {
 }
 
 func decode(reader io.ReadCloser, decoder runtime.Decoder) (runtime.Object, error) {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/template/controller/templateinstance_controller_test.go
+++ b/pkg/template/controller/templateinstance_controller_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -72,7 +72,7 @@ func TestControllerCheckReadiness(t *testing.T) {
 				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewBuffer(b)),
+					Body:       io.NopCloser(bytes.NewBuffer(b)),
 				}, nil
 			})
 		},


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration away from `ioutil`:**

* Replaced `ioutil.TempFile` with `os.CreateTemp` for creating temporary files in `build_controller_test.go`.
* Updated `ioutil.NopCloser` to `io.NopCloser` and `ioutil.ReadAll` to `io.ReadAll` in `imagestream_controller_test.go` and `templateinstance_controller_test.go`. [[1]](diffhunk://#diff-ed14ea08bf29de986ec841f333fcf464edd05cd7d2c915f9dc6df88cdcad6b72L481-R480) [[2]](diffhunk://#diff-ed14ea08bf29de986ec841f333fcf464edd05cd7d2c915f9dc6df88cdcad6b72L491-R490) [[3]](diffhunk://#diff-524285fa1b2b38ad5ea977261423f40b246a9d21b494bfe91aed44c6b006d48dL75-R75)

**Cleanup of imports:**

* Removed unused `ioutil` imports and added `io` where necessary in test files. [[1]](diffhunk://#diff-f9dd124586d829d2637e4e7cf696b5f945592c87d8dc6e231aef885e24796596L6) [[2]](diffhunk://#diff-ed14ea08bf29de986ec841f333fcf464edd05cd7d2c915f9dc6df88cdcad6b72L8) [[3]](diffhunk://#diff-524285fa1b2b38ad5ea977261423f40b246a9d21b494bfe91aed44c6b006d48dL6-R6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use modern Go APIs for file and I/O operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->