### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,12 @@
 reviewers:
+  - control-plane-approvers
   - csrwng
   - sayan-biswas
   - sanchezl
   - prabhapa
   - moebasim
 approvers:
+  - control-plane-approvers
   - adambkaplan
   - sayan-biswas
   - sanchezl

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established control-plane-approvers group for code review and approval processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->