### PR TITLE
Migrate CRI-O annotations to v2 format

### DIFF
--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -601,14 +601,14 @@ func builderMinSecurityContext() *corev1.SecurityContext {
 // Reference: https://github.com/openshift/machine-config-operator/pull/2805
 func setupBuilderDeviceFUSE(pod *corev1.Pod) {
 	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "io.openshift.builder", "")
-	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "io.kubernetes.cri-o.Devices", "/dev/fuse:rwm")
+	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "devices.crio.io", "/dev/fuse:rwm")
 }
 
 // Request that the builder be run in a user namespace, mapped from host ID
 // ranges chosen by the node.
 func setupBuilderAutonsUser(build *buildv1.Build, vars []corev1.EnvVar, pod *corev1.Pod) {
 	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "io.openshift.builder", "")
-	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "io.kubernetes.cri-o.userns-mode", "auto:size=65536")
+	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "userns-mode.crio.io", "auto:size=65536")
 }
 
 // setupBuildCAs mounts certificate authorities for the build from a predetermined ConfigMap.

--- a/pkg/build/controller/strategy/util_test.go
+++ b/pkg/build/controller/strategy/util_test.go
@@ -811,17 +811,17 @@ func testCreateBuildPodAutonsUser(t *testing.T, build *buildv1.Build, strategy b
 			privileged: true,
 			noAnnotations: []string{
 				"io.openshift.builder",
-				"io.kubernetes.cri-o.Devices",
-				"io.kubernetes.cri-o.userns-mode",
+				"devices.crio.io",
+				"userns-mode.crio.io",
 			},
 		},
 		{
 			env:        "BUILD_PRIVILEGED=0",
 			privileged: false,
 			annotations: map[string]string{
-				"io.openshift.builder":            "",
-				"io.kubernetes.cri-o.Devices":     "/dev/fuse:rwm",
-				"io.kubernetes.cri-o.userns-mode": "auto:size=65536",
+				"io.openshift.builder": "",
+				"devices.crio.io":      "/dev/fuse:rwm",
+				"userns-mode.crio.io":  "auto:size=65536",
 			},
 		},
 		{
@@ -829,17 +829,17 @@ func testCreateBuildPodAutonsUser(t *testing.T, build *buildv1.Build, strategy b
 			privileged: true,
 			noAnnotations: []string{
 				"io.openshift.builder",
-				"io.kubernetes.cri-o.Devices",
-				"io.kubernetes.cri-o.userns-mode",
+				"devices.crio.io",
+				"userns-mode.crio.io",
 			},
 		},
 		{
 			env:        "BUILD_PRIVILEGED=false",
 			privileged: false,
 			annotations: map[string]string{
-				"io.openshift.builder":            "",
-				"io.kubernetes.cri-o.Devices":     "/dev/fuse:rwm",
-				"io.kubernetes.cri-o.userns-mode": "auto:size=65536",
+				"io.openshift.builder": "",
+				"devices.crio.io":      "/dev/fuse:rwm",
+				"userns-mode.crio.io":  "auto:size=65536",
 			},
 		},
 		{
@@ -847,8 +847,8 @@ func testCreateBuildPodAutonsUser(t *testing.T, build *buildv1.Build, strategy b
 			privileged: true,
 			noAnnotations: []string{
 				"io.openshift.builder",
-				"io.kubernetes.cri-o.Devices",
-				"io.kubernetes.cri-o.userns-mode",
+				"devices.crio.io",
+				"userns-mode.crio.io",
 			},
 		},
 	} {


### PR DESCRIPTION
CRI-O migrated its annotations from v1 (`io.kubernetes.cri-o.*`) to v2 (`*.crio.io`) format. The old format is deprecated. This updates the builder pod annotations accordingly:
- `io.kubernetes.cri-o.Devices` -> `devices.crio.io`
- `io.kubernetes.cri-o.userns-mode` -> `userns-mode.crio.io`

Tracking: https://github.com/cri-o/cri-o/issues/10194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build pod annotations to use current CRI-O annotation keys for FUSE device access and automatic user namespace mode.
  * Preserved existing builder behavior for clearing related `io.openshift.builder` annotations.
* **Tests**
  * Updated unit test expectations to match the new CRI-O annotation keys across privileged build scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->